### PR TITLE
fix: force Node.js 24 for softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The action softprops/action-gh-release@v2 still runs on Node.js 20. Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to opt into Node.js 24 before the June 2nd, 2026 deadline.