### PR TITLE
feat: comprehensive test coverage for zotadata.js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code

--- a/docs/superpowers/plans/2026-03-23-test-coverage-implementation.md
+++ b/docs/superpowers/plans/2026-03-23-test-coverage-implementation.md
@@ -1,0 +1,3149 @@
+# Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement comprehensive test coverage for zotadata.js functions prioritized by refactoring risk, providing a safety net for TypeScript migration.
+
+**Architecture:** Stratified test approach with 4 tiers: Critical (pure functions), High Priority (API clients), Medium Priority (batch processing), and Lower Priority (UI code). Tests use Vitest with mock infrastructure extending existing setup.ts.
+
+**Tech Stack:** Vitest, TypeScript, vi.fn() mocking, fixture-driven API response testing
+
+---
+
+## File Structure
+
+```
+tests/
+├── __mocks__/
+│   ├── zotero.ts              # Core Zotero mock (extend setup.ts)
+│   ├── zotero-items.ts        # Item mock factory
+│   ├── zotero-http.ts         # HTTP request mock with fixtures
+│   ├── zotero-translate.ts    # Zotero.Translate.Search mock
+│   ├── zotero-prefs.ts        # Zotero.Prefs mock
+│   └── fixtures/
+│       ├── crossref.ts        # CrossRef API response fixtures
+│       ├── openalex.ts        # OpenAlex API response fixtures
+│       ├── semanticscholar.ts # Semantic Scholar response fixtures
+│       └── arxiv.ts           # arXiv API response fixtures
+└── unit/
+    └── zotadata/
+        ├── utils.test.ts          # Tier 1: titleSimilarity, sanitize, validate
+        ├── extractors.test.ts     # Tier 1: DOI, ISBN, arXiv extraction
+        ├── isbn-convert.test.ts   # Tier 1: ISBN-10/13 conversion
+        ├── api-clients.test.ts    # Tier 2: HTTP clients with mocks
+        ├── discovery.test.ts      # Tier 2: DOI/ISBN discovery orchestration
+        ├── metadata.test.ts       # Tier 2: metadata fetching
+        ├── arxiv-processing.test.ts # Tier 2: arXiv pipeline
+        ├── file-operations.test.ts # Tier 2-3: file finding and download
+        ├── batch-processing.test.ts # Tier 3: batch operations
+        └── integration.test.ts    # Tier 3: end-to-end with full mocks
+```
+
+---
+
+## Task 1: Mock Infrastructure Setup
+
+**Files:**
+- Create: `tests/__mocks__/zotero-items.ts`
+- Create: `tests/__mocks__/zotero-http.ts`
+- Create: `tests/__mocks__/zotero-translate.ts`
+- Create: `tests/__mocks__/zotero-prefs.ts`
+- Modify: `src/__tests__/setup.ts`
+
+- [ ] **Step 1: Write test for item mock factory**
+
+```typescript
+// tests/__mocks__/zotero-items.test.ts
+import { describe, it, expect } from 'vitest';
+import { createMockItem, createMockAttachment } from './zotero-items';
+
+describe('createMockItem', () => {
+  it('should create item with default fields', () => {
+    const item = createMockItem();
+    expect(item.getField('title')).toBe('Test Title');
+    expect(item.id).toBeDefined();
+  });
+
+  it('should create item with custom fields', () => {
+    const item = createMockItem({
+      title: 'Custom Title',
+      DOI: '10.1000/test.doi'
+    });
+    expect(item.getField('title')).toBe('Custom Title');
+    expect(item.getField('DOI')).toBe('10.1000/test.doi');
+  });
+
+  it('should support setField and getField', () => {
+    const item = createMockItem();
+    item.setField('title', 'New Title');
+    expect(item.getField('title')).toBe('New Title');
+  });
+});
+
+describe('createMockAttachment', () => {
+  it('should create attachment with link mode', () => {
+    const attachment = createMockAttachment({
+      linkMode: 2 // LINK_MODE_IMPORTED_FILE
+    });
+    expect(attachment.attachmentLinkMode).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test tests/__mocks__/zotero-items.test.ts`
+Expected: FAIL - cannot find module './zotero-items'
+
+- [ ] **Step 3: Write item mock factory implementation**
+
+```typescript
+// tests/__mocks__/zotero-items.ts
+import { vi } from 'vitest';
+
+export interface MockItemConfig {
+  id?: number;
+  itemTypeID?: number;
+  title?: string;
+  DOI?: string;
+  ISBN?: string;
+  url?: string;
+  extra?: string;
+  publicationTitle?: string;
+  date?: string;
+  creators?: Array<{ firstName?: string; lastName?: string }>;
+}
+
+let itemCounter = 0;
+
+export function createMockItem(config: MockItemConfig = {}) {
+  const id = config.id ?? ++itemCounter;
+  const fields: Record<string, string> = {
+    title: config.title ?? 'Test Title',
+    DOI: config.DOI ?? '',
+    ISBN: config.ISBN ?? '',
+    url: config.url ?? '',
+    extra: config.extra ?? '',
+    publicationTitle: config.publicationTitle ?? '',
+    date: config.date ?? '',
+  };
+
+  const creators = config.creators ?? [];
+
+  const tags: Array<{ tag: string; type: number }> = [];
+
+  return {
+    id,
+    itemTypeID: config.itemTypeID ?? 1, // journalArticle
+    get id() { return id; },
+
+    getField: vi.fn((fieldName: string) => fields[fieldName] ?? ''),
+    setField: vi.fn((fieldName: string, value: string) => {
+      fields[fieldName] = value;
+    }),
+
+    getCreators: vi.fn(() => creators),
+    getAttachments: vi.fn(() => []),
+
+    hasTag: vi.fn((tagName: string) => tags.some(t => t.tag === tagName)),
+    addTag: vi.fn((tag: string, type: number = 0) => {
+      tags.push({ tag, type });
+    }),
+
+    saveTx: vi.fn(async () => id),
+    eraseTx: vi.fn(async () => {}),
+    setType: vi.fn(() => {}),
+  } as any;
+}
+
+export interface MockAttachmentConfig {
+  id?: number;
+  linkMode?: number;
+  filePath?: string | null;
+  fileExists?: boolean;
+}
+
+let attachmentCounter = 0;
+
+export function createMockAttachment(config: MockAttachmentConfig = {}) {
+  const id = config.id ?? ++attachmentCounter;
+  const filePath = config.filePath;
+  const fileExists = config.fileExists ?? (filePath !== null && filePath !== undefined);
+
+  return {
+    id,
+    attachmentLinkMode: config.linkMode ?? 2,
+    getFilePath: vi.fn(() => filePath ?? null),
+    getFile: vi.fn(() => fileExists ? { exists: () => true } : null),
+    eraseTx: vi.fn(async () => {}),
+  } as any;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test tests/__mocks__/zotero-items.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write HTTP mock with fixture support**
+
+```typescript
+// tests/__mocks__/zotero-http.ts
+import { vi } from 'vitest';
+
+export interface MockResponse {
+  status: number;
+  responseText: string;
+  getResponseHeader?: (name: string) => string | null;
+}
+
+export type FixtureLoader = (url: string) => MockResponse | null;
+
+const fixtures: Map<string, MockResponse> = new Map();
+const fixtureLoaders: FixtureLoader[] = [];
+
+export function registerFixture(urlPattern: string | RegExp, response: MockResponse) {
+  fixtures.set(urlPattern.toString(), response);
+}
+
+export function registerFixtureLoader(loader: FixtureLoader) {
+  fixtureLoaders.push(loader);
+}
+
+export function clearFixtures() {
+  fixtures.clear();
+}
+
+export function createMockHTTP() {
+  return {
+    request: vi.fn(async (method: string, url: string, _options?: any) => {
+      // Check fixtures first
+      for (const [pattern, response] of fixtures) {
+        if (url.match(pattern.replace(/^\/|\/$/g, ''))) {
+          return response;
+        }
+      }
+
+      // Check fixture loaders
+      for (const loader of fixtureLoaders) {
+        const response = loader(url);
+        if (response) return response;
+      }
+
+      // Default 404
+      return {
+        status: 404,
+        responseText: '{}',
+        getResponseHeader: () => null,
+      };
+    }),
+  };
+}
+```
+
+- [ ] **Step 6: Write translator mock**
+
+```typescript
+// tests/__mocks__/zotero-translate.ts
+import { vi } from 'vitest';
+
+export interface MockTranslatorConfig {
+  found?: boolean;
+  item?: {
+    title?: string;
+    creators?: Array<{ firstName: string; lastName: string }>;
+    [key: string]: any;
+  };
+}
+
+export function createMockTranslate(config: MockTranslatorConfig = {}) {
+  return vi.fn().mockImplementation(() => ({
+    setSearch: vi.fn(),
+    setHandler: vi.fn((_type: string, callback: (items: any[]) => void) => {
+      if (config.found && config.item) {
+        setTimeout(() => callback([config.item]), 0);
+      } else {
+        setTimeout(() => callback([]), 0);
+      }
+    }),
+    translate: vi.fn(),
+  }));
+}
+
+// Add to global Zotero mock
+export function setupTranslateMock(config?: MockTranslatorConfig) {
+  const mock = createMockTranslate(config);
+  (globalThis as any).Zotero.Translate = {
+    Search: mock,
+  };
+  return mock;
+}
+```
+
+- [ ] **Step 7: Write Prefs mock**
+
+```typescript
+// tests/__mocks__/zotero-prefs.ts
+import { vi } from 'vitest';
+
+const prefs: Map<string, any> = new Map();
+
+export function createMockPrefs() {
+  return {
+    get: vi.fn((key: string, defaultValue?: any) => {
+      return prefs.has(key) ? prefs.get(key) : defaultValue;
+    }),
+    set: vi.fn((key: string, value: any) => {
+      prefs.set(key, value);
+    }),
+    clear: vi.fn((key: string) => {
+      prefs.delete(key);
+    }),
+  };
+}
+
+export function setPref(key: string, value: any) {
+  prefs.set(key, value);
+}
+
+export function clearPrefs() {
+  prefs.clear();
+}
+```
+
+- [ ] **Step 8: Update setup.ts to integrate mocks**
+
+```typescript
+// src/__tests__/setup.ts
+// Add to existing file after the ChromeUtils mock
+
+// Import mock utilities
+import { createMockHTTP } from '../../tests/__mocks__/zotero-http';
+import { createMockPrefs } from '../../tests/__mocks__/zotero-prefs';
+
+// Extend Zotero mock with test utilities
+(globalThis as any).Zotero.Prefs = createMockPrefs();
+
+// Store original HTTP mock
+const originalHTTP = (globalThis as any).Zotero.HTTP;
+
+// Helper to reset HTTP mock with fixtures
+(globalThis as any).__resetHTTPMock = () => {
+  (globalThis as any).Zotero.HTTP = createMockHTTP();
+};
+
+// Helper to set custom HTTP mock
+(globalThis as any).__setHTTPMock = (mock: any) => {
+  (globalThis as any).Zotero.HTTP = mock;
+};
+
+// Reset mocks between tests
+beforeEach(() => {
+  (globalThis as any).__resetHTTPMock?.();
+});
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/__mocks__/ src/__tests__/setup.ts
+git commit -m "feat: add mock infrastructure for zotadata tests
+
+- Add item mock factory with field/creator support
+- Add HTTP mock with fixture loading
+- Add Zotero.Translate.Search mock
+- Add Zotero.Prefs mock"
+```
+
+---
+
+## Task 2: API Fixtures
+
+**Files:**
+- Create: `tests/__mocks__/fixtures/crossref.ts`
+- Create: `tests/__mocks__/fixtures/openalex.ts`
+- Create: `tests/__mocks__/fixtures/semanticscholar.ts`
+- Create: `tests/__mocks__/fixtures/arxiv.ts`
+
+- [ ] **Step 1: Write CrossRef fixtures**
+
+```typescript
+// tests/__mocks__/fixtures/crossref.ts
+export const crossrefFixtures = {
+  singleWork: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [{
+          DOI: '10.1000/test.doi',
+          title: ['Test Paper Title'],
+          author: [{ given: 'John', family: 'Smith' }],
+          'published-print': { 'date-parts': [[2023]] },
+          type: 'journal-article',
+        }],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  multipleWorks: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [
+          {
+            DOI: '10.1000/test1.doi',
+            title: ['First Paper'],
+            author: [{ given: 'John', family: 'Smith' }],
+            type: 'journal-article',
+          },
+          {
+            DOI: '10.1000/test2.doi',
+            title: ['Second Paper'],
+            author: [{ given: 'Jane', family: 'Doe' }],
+            type: 'journal-article',
+          },
+        ],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: { items: [] },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  arxivMatch: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [{
+          DOI: '10.1000/published.doi',
+          title: ['Published Version of arXiv Paper'],
+          type: 'journal-article',
+        }],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  metadata: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        DOI: '10.1000/test.doi',
+        title: ['Full Metadata Paper'],
+        author: [
+          { given: 'John', family: 'Smith' },
+          { given: 'Jane', family: 'Doe' },
+        ],
+        'container-title': ['Test Journal'],
+        'published-print': { 'date-parts': [[2023, 5, 15]] },
+        volume: '10',
+        issue: '2',
+        page: '123-145',
+        type: 'journal-article',
+        URL: 'https://doi.org/10.1000/test.doi',
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  rateLimited: {
+    status: 429,
+    responseText: JSON.stringify({
+      message: 'Rate limit exceeded',
+    }),
+    getResponseHeader: () => null,
+  },
+
+  serverError: {
+    status: 500,
+    responseText: JSON.stringify({
+      message: 'Internal server error',
+    }),
+    getResponseHeader: () => null,
+  },
+};
+```
+
+- [ ] **Step 2: Write OpenAlex fixtures**
+
+```typescript
+// tests/__mocks__/fixtures/openalex.ts
+export const openalexFixtures = {
+  singleWork: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [{
+        id: 'https://openalex.org/W123456789',
+        display_name: 'Test Paper Title',
+        authorships: [
+          { author: { display_name: 'John Smith' } },
+        ],
+        publication_year: 2023,
+        doi: 'https://doi.org/10.1000/test.doi',
+        open_access: { is_oa: false },
+      }],
+      meta: { count: 1 },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  withPdf: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [{
+        id: 'https://openalex.org/W123456789',
+        display_name: 'Open Access Paper',
+        doi: 'https://doi.org/10.1000/oa.doi',
+        open_access: {
+          is_oa: true,
+          oa_url: 'https://example.com/paper.pdf',
+        },
+      }],
+      meta: { count: 1 },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [],
+      meta: { count: 0 },
+    }),
+    getResponseHeader: () => null,
+  },
+};
+```
+
+- [ ] **Step 3: Write Semantic Scholar fixtures**
+
+```typescript
+// tests/__mocks__/fixtures/semanticscholar.ts
+export const semanticscholarFixtures = {
+  singlePaper: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'abc123',
+        title: 'Test Paper Title',
+        year: 2023,
+        venue: 'Test Conference',
+        externalIds: { DOI: '10.1000/test.doi' },
+        authors: [{ name: 'John Smith' }],
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  arxivPaper: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'arxiv123',
+        title: 'arXiv Paper',
+        venue: 'arXiv',
+        externalIds: { ArXiv: '2301.12345' },
+        authors: [{ name: 'Jane Doe' }],
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  publishedVersion: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'pub123',
+        title: 'Published Version',
+        venue: 'Nature',
+        year: 2024,
+        externalIds: { DOI: '10.1000/published.doi' },
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({ data: [] }),
+    getResponseHeader: () => null,
+  },
+};
+```
+
+- [ ] **Step 4: Write arXiv fixtures**
+
+```typescript
+// tests/__mocks__/fixtures/arxiv.ts
+export const arxivFixtures = {
+  singleEntry: {
+    status: 200,
+    responseText: `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2301.12345</id>
+    <title>Test arXiv Paper</title>
+    <author><name>John Smith</name></author>
+    <summary>Abstract text</summary>
+    <link href="http://arxiv.org/pdf/2301.12345" rel="alternate" type="application/pdf"/>
+  </entry>
+</feed>`,
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>`,
+    getResponseHeader: () => null,
+  },
+};
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/__mocks__/fixtures/
+git commit -m "feat: add API response fixtures for CrossRef, OpenAlex, Semantic Scholar, arXiv"
+```
+
+---
+
+## Task 3: Tier 1 - Utils Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/utils.test.ts`
+
+- [ ] **Step 1: Write failing tests for titleSimilarity**
+
+```typescript
+// tests/unit/zotadata/utils.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Import the Zotadata object - will need to handle this since it's in a JS file
+// For now, we'll extract functions for testing
+let Zotadata: any;
+
+beforeEach(async () => {
+  // Load the zotadata.js module
+  // Since it's a JS file that relies on Zotero globals, we need special handling
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const zotadataPath = path.join(process.cwd(), 'addon/chrome/content/scripts/zotadata.js');
+  const code = fs.readFileSync(zotadataPath, 'utf-8');
+
+  // Extract titleSimilarity function
+  const match = code.match(/titleSimilarity\(title1,\s*title2\)\s*\{[\s\S]*?(?=\n\s{4},|\n\s{4}\/\/|\n\s{4}async)/);
+  if (match) {
+    const funcCode = match[0];
+    // Create function from extracted code
+    Zotadata = {
+      titleSimilarity: new Function('title1', 'title2',
+        funcCode.replace(/titleSimilarity\(title1,\s*title2\)\s*\{/, '').replace(/\}$/, '')
+      )
+    };
+  }
+});
+
+describe('titleSimilarity', () => {
+  it('should return 1.0 for exact match', () => {
+    const result = Zotadata.titleSimilarity('Test Title', 'Test Title');
+    expect(result).toBe(1.0);
+  });
+
+  it('should be case insensitive', () => {
+    const result = Zotadata.titleSimilarity('Test Title', 'TEST TITLE');
+    expect(result).toBe(1.0);
+  });
+
+  it('should ignore stop words', () => {
+    const result = Zotadata.titleSimilarity(
+      'The Test of the Title',
+      'Test Title'
+    );
+    expect(result).toBeGreaterThan(0.8);
+  });
+
+  it('should handle punctuation', () => {
+    const result = Zotadata.titleSimilarity(
+      'Test-Title: A Study',
+      'Test Title A Study'
+    );
+    expect(result).toBeGreaterThan(0.9);
+  });
+
+  it('should calculate partial overlap correctly', () => {
+    const result = Zotadata.titleSimilarity(
+      'Machine Learning in Healthcare',
+      'Healthcare Applications of Machine Learning'
+    );
+    expect(result).toBeGreaterThan(0.4);
+    expect(result).toBeLessThan(0.8);
+  });
+
+  it('should return 0 for no overlap', () => {
+    const result = Zotadata.titleSimilarity(
+      'Completely Different Title',
+      'No Shared Words Here'
+    );
+    expect(result).toBe(0);
+  });
+
+  it('should handle unicode/international characters', () => {
+    const result = Zotadata.titleSimilarity(
+      'Méthode de Calcul',
+      'Methode de Calcul'
+    );
+    expect(result).toBeGreaterThan(0.8);
+  });
+
+  it('should handle LaTeX-style mathematical symbols', () => {
+    const result = Zotadata.titleSimilarity(
+      'On the $\\alpha$-Conjecture',
+      'On the alpha Conjecture'
+    );
+    expect(result).toBeGreaterThan(0.7);
+  });
+
+  it('should handle very long titles', () => {
+    const longTitle = 'A '.repeat(100) + 'Very Long Title';
+    const result = Zotadata.titleSimilarity(longTitle, longTitle);
+    expect(result).toBe(1.0);
+  });
+
+  it('should handle empty/null inputs gracefully', () => {
+    expect(Zotadata.titleSimilarity('', '')).toBe(1.0);
+    expect(Zotadata.titleSimilarity('Test', '')).toBe(0);
+    expect(Zotadata.titleSimilarity(null as any, 'Test')).toBe(0);
+    expect(Zotadata.titleSimilarity('Test', undefined as any)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test tests/unit/zotadata/utils.test.ts`
+Expected: FAIL - need to implement function extraction
+
+- [ ] **Step 3: Create test helper for extracting functions**
+
+```typescript
+// tests/helpers/extract-function.ts
+import fs from 'fs';
+import path from 'path';
+
+const zotadataCache: Map<string, Function> = new Map();
+
+export function extractFunction(name: string): Function | null {
+  if (zotadataCache.has(name)) {
+    return zotadataCache.get(name)!;
+  }
+
+  const zotadataPath = path.join(process.cwd(), 'addon/chrome/content/scripts/zotadata.js');
+  const code = fs.readFileSync(zotadataPath, 'utf-8');
+
+  // Match function definition in Zotadata object
+  const regex = new RegExp(
+    `${name}\\([^)]*\\)\\s*\\{([\\s\\S]*?)(?=\\n\\s{4}[a-zA-Z_]+\\(|\\n\\s{4}\\})`,
+    'm'
+  );
+
+  const match = code.match(regex);
+  if (!match) return null;
+
+  // Extract parameter names
+  const paramMatch = code.match(new RegExp(`${name}\\(([^)]*)\\)`));
+  const params = paramMatch ? paramMatch[1].split(',').map(p => p.trim()) : [];
+
+  // Create function
+  const fn = new Function(...params, match[1]);
+  zotadataCache.set(name, fn);
+  return fn;
+}
+
+// For methods that use `this.log()`, we need to bind context
+export function createZotadataMethod(name: string, context: any = {}) {
+  const fn = extractFunction(name);
+  if (!fn) throw new Error(`Function ${name} not found`);
+
+  const defaultContext = {
+    log: () => {},
+    ...context,
+  };
+
+  return fn.bind(defaultContext);
+}
+```
+
+- [ ] **Step 4: Update utils.test.ts to use helper**
+
+```typescript
+// tests/unit/zotadata/utils.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+
+describe('titleSimilarity', () => {
+  let titleSimilarity: (t1: string, t2: string) => number;
+
+  beforeEach(() => {
+    titleSimilarity = createZotadataMethod('titleSimilarity');
+  });
+
+  it('should return 1.0 for exact match', () => {
+    expect(titleSimilarity('Test Title', 'Test Title')).toBe(1.0);
+  });
+
+  it('should be case insensitive', () => {
+    expect(titleSimilarity('Test Title', 'TEST TITLE')).toBe(1.0);
+  });
+
+  it('should ignore stop words', () => {
+    expect(titleSimilarity('The Test of the Title', 'Test Title')).toBeGreaterThan(0.8);
+  });
+
+  it('should handle punctuation', () => {
+    expect(titleSimilarity('Test-Title: A Study', 'Test Title A Study')).toBeGreaterThan(0.9);
+  });
+
+  it('should calculate partial overlap correctly', () => {
+    const result = titleSimilarity(
+      'Machine Learning in Healthcare',
+      'Healthcare Applications of Machine Learning'
+    );
+    expect(result).toBeGreaterThan(0.4);
+    expect(result).toBeLessThan(0.8);
+  });
+
+  it('should return 0 for no overlap', () => {
+    expect(titleSimilarity('Completely Different Title', 'No Shared Words Here')).toBe(0);
+  });
+
+  it('should handle unicode/international characters', () => {
+    expect(titleSimilarity('Méthode de Calcul', 'Methode de Calcul')).toBeGreaterThan(0.8);
+  });
+
+  it('should handle LaTeX-style mathematical symbols', () => {
+    expect(titleSimilarity('On the $\\alpha$-Conjecture', 'On the alpha Conjecture')).toBeGreaterThan(0.7);
+  });
+
+  it('should handle very long titles', () => {
+    const longTitle = 'A '.repeat(100) + 'Very Long Title';
+    expect(titleSimilarity(longTitle, longTitle)).toBe(1.0);
+  });
+
+  it('should handle empty/null inputs gracefully', () => {
+    expect(titleSimilarity('', '')).toBe(1.0);
+    expect(titleSimilarity('Test', '')).toBe(0);
+    expect(titleSimilarity(null as any, 'Test')).toBe(0);
+    expect(titleSimilarity('Test', undefined as any)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 5: Write tests for sanitizeFileName**
+
+```typescript
+describe('sanitizeFileName', () => {
+  let sanitizeFileName: (name: string) => string;
+
+  beforeEach(() => {
+    sanitizeFileName = createZotadataMethod('sanitizeFileName');
+  });
+
+  it('should replace invalid characters with underscore', () => {
+    expect(sanitizeFileName('file<>name')).toBe('file__name');
+    expect(sanitizeFileName('file:name')).toBe('file_name');
+    expect(sanitizeFileName('file"name')).toBe('file_name');
+    expect(sanitizeFileName('file/name\\name')).toBe('file_name_name');
+  });
+
+  it('should replace spaces with underscores', () => {
+    expect(sanitizeFileName('file name test')).toBe('file_name_test');
+  });
+
+  it('should limit length to 100 characters', () => {
+    const longName = 'a'.repeat(150);
+    expect(sanitizeFileName(longName)).toHaveLength(100);
+  });
+
+  it('should return "attachment" for empty input', () => {
+    expect(sanitizeFileName('')).toBe('attachment');
+    expect(sanitizeFileName(null as any)).toBe('attachment');
+  });
+
+  it('should handle unicode characters', () => {
+    const result = sanitizeFileName('Méthode de Calcul');
+    expect(result).toContain('M');
+  });
+});
+```
+
+- [ ] **Step 6: Write tests for cleanDownloadUrl**
+
+```typescript
+describe('cleanDownloadUrl', () => {
+  let cleanDownloadUrl: (url: string) => string;
+
+  beforeEach(() => {
+    cleanDownloadUrl = createZotadataMethod('cleanDownloadUrl');
+  });
+
+  it('should remove fragment identifiers', () => {
+    expect(cleanDownloadUrl('https://example.com/file.pdf#page=1'))
+      .toBe('https://example.com/file.pdf');
+  });
+
+  it('should fix double slashes in path', () => {
+    expect(cleanDownloadUrl('https://example.com//path//file.pdf'))
+      .toBe('https://example.com/path/file.pdf');
+  });
+
+  it('should remove problematic query parameters', () => {
+    const url = 'https://example.com/file.pdf?navpanes=0&view=FitH';
+    const result = cleanDownloadUrl(url);
+    expect(result).not.toContain('navpanes');
+    expect(result).not.toContain('view');
+  });
+
+  it('should return original URL on error', () => {
+    expect(cleanDownloadUrl('invalid-url')).toBe('invalid-url');
+  });
+
+  it('should handle null/undefined', () => {
+    expect(cleanDownloadUrl(null as any)).toBe(null);
+    expect(cleanDownloadUrl(undefined as any)).toBe(undefined);
+  });
+});
+```
+
+- [ ] **Step 7: Write tests for validatePDFData**
+
+```typescript
+describe('validatePDFData', () => {
+  let validatePDFData: (data: Uint8Array) => boolean;
+
+  beforeEach(() => {
+    validatePDFData = createZotadataMethod('validatePDFData');
+  });
+
+  it('should validate PDF with correct header and trailer', () => {
+    const pdfData = new TextEncoder().encode('%PDF-1.4\ncontent\n%%EOF');
+    expect(validatePDFData(pdfData)).toBe(true);
+  });
+
+  it('should reject data too small to be valid PDF', () => {
+    const smallData = new Uint8Array(100);
+    expect(validatePDFData(smallData)).toBe(false);
+  });
+
+  it('should reject data without PDF header', () => {
+    const invalidData = new TextEncoder().encode('Not a PDF'.repeat(200));
+    expect(validatePDFData(invalidData)).toBe(false);
+  });
+
+  it('should accept PDF without %%EOF trailer', () => {
+    // Some PDFs might not have the trailer
+    const pdfNoTrailer = new TextEncoder().encode('%PDF-1.4\n' + 'content '.repeat(200));
+    // Should still pass (trailer is just a warning)
+    expect(validatePDFData(pdfNoTrailer)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 8: Run all utils tests**
+
+Run: `npm test tests/unit/zotadata/utils.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/unit/zotadata/utils.test.ts tests/helpers/extract-function.ts
+git commit -m "test: add Tier 1 utils tests (titleSimilarity, sanitize, cleanUrl, validatePDF)"
+```
+
+---
+
+## Task 4: Tier 1 - Extractors Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/extractors.test.ts`
+
+- [ ] **Step 1: Write tests for extractDOI**
+
+```typescript
+// tests/unit/zotadata/extractors.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+
+// Mock Zotero.Utilities
+(globalThis as any).Zotero = {
+  Utilities: {
+    cleanDOI: (doi: string) => doi.trim().toLowerCase(),
+  },
+};
+
+describe('extractDOI', () => {
+  let extractDOI: (item: any) => string | null;
+
+  beforeEach(() => {
+    extractDOI = createZotadataMethod('extractDOI');
+  });
+
+  it('should extract DOI from DOI field', () => {
+    const item = createMockItem({ DOI: '10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from URL with doi.org pattern', () => {
+    const item = createMockItem({ url: 'https://doi.org/10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from URL with dx.doi.org pattern', () => {
+    const item = createMockItem({ url: 'https://dx.doi.org/10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from extra field', () => {
+    const item = createMockItem({ extra: 'DOI: 10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should handle various DOI formats', () => {
+    const item = createMockItem({ DOI: '10.1234/abc.def-ghi_123' });
+    expect(extractDOI(item)).toBe('10.1234/abc.def-ghi_123');
+  });
+
+  it('should return null for item without DOI', () => {
+    const item = createMockItem({ title: 'No DOI Here' });
+    expect(extractDOI(item)).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 2: Write tests for extractISBN**
+
+```typescript
+describe('extractISBN', () => {
+  let extractISBN: (item: any) => string | null;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.Utilities.cleanISBN = (isbn: string) =>
+      isbn.replace(/[^0-9X]/gi, '');
+    extractISBN = createZotadataMethod('extractISBN');
+  });
+
+  it('should extract ISBN-13 from ISBN field', () => {
+    const item = createMockItem({ ISBN: '978-0-123456-78-9' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should extract ISBN-10 from ISBN field', () => {
+    const item = createMockItem({ ISBN: '0-123456-78-X' });
+    expect(extractISBN(item)).toBe('012345678X');
+  });
+
+  it('should extract ISBN from extra field', () => {
+    const item = createMockItem({ extra: 'ISBN: 9780123456789' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should return null for item without ISBN', () => {
+    const item = createMockItem({ title: 'No ISBN' });
+    expect(extractISBN(item)).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 3: Write tests for extractArxivId**
+
+```typescript
+describe('extractArxivId', () => {
+  let extractArxivId: (item: any) => string | null;
+
+  beforeEach(() => {
+    extractArxivId = createZotadataMethod('extractArxivId');
+  });
+
+  it('should extract arXiv ID from extra field', () => {
+    const item = createMockItem({ extra: 'arXiv:2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should extract arXiv ID from URL', () => {
+    const item = createMockItem({ url: 'https://arxiv.org/abs/2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should return null for non-arXiv item', () => {
+    const item = createMockItem({ title: 'Regular Paper' });
+    expect(extractArxivId(item)).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 4: Write tests for isArxivItem**
+
+```typescript
+describe('isArxivItem', () => {
+  let isArxivItem: (item: any) => boolean;
+
+  beforeEach(() => {
+    isArxivItem = createZotadataMethod('isArxivItem');
+  });
+
+  it('should detect arXiv from publicationTitle', () => {
+    const item = createMockItem({ publicationTitle: 'arXiv' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from URL', () => {
+    const item = createMockItem({ url: 'https://arxiv.org/abs/2301.12345' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from extra field', () => {
+    const item = createMockItem({ extra: 'arXiv:2301.12345' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from title', () => {
+    const item = createMockItem({ title: 'arXiv preprint: Some Title' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should return false for non-arXiv item', () => {
+    const item = createMockItem({
+      title: 'Regular Paper',
+      publicationTitle: 'Nature',
+    });
+    expect(isArxivItem(item)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test tests/unit/zotadata/extractors.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/unit/zotadata/extractors.test.ts
+git commit -m "test: add Tier 1 extractor tests (DOI, ISBN, arXiv)"
+```
+
+---
+
+## Task 5: Tier 1 - ISBN Conversion Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/isbn-convert.test.ts`
+
+- [ ] **Step 1: Write ISBN conversion tests**
+
+```typescript
+// tests/unit/zotadata/isbn-convert.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+
+describe('convertISBN10to13', () => {
+  let convertISBN10to13: (isbn: string) => string | null;
+
+  beforeEach(() => {
+    convertISBN10to13 = createZotadataMethod('convertISBN10to13');
+  });
+
+  it('should convert valid ISBN-10 to ISBN-13', () => {
+    // 0-306-40615-2 -> 978-0-306-40615-7
+    const result = convertISBN10to13('0306406152');
+    expect(result).toBe('9780306406157');
+  });
+
+  it('should handle ISBN-10 with X check digit', () => {
+    // 0-201-63361-X -> 978-0-201-63361-0
+    const result = convertISBN10to13('020163361X');
+    expect(result).toBe('9780201633610');
+  });
+
+  it('should return null for invalid length', () => {
+    expect(convertISBN10to13('12345')).toBe(null);
+    expect(convertISBN10to13('12345678901234')).toBe(null);
+  });
+});
+
+describe('convertISBN13to10', () => {
+  let convertISBN13to10: (isbn: string) => string | null;
+
+  beforeEach(() => {
+    convertISBN13to10 = createZotadataMethod('convertISBN13to10');
+  });
+
+  it('should convert valid 978-prefix ISBN-13 to ISBN-10', () => {
+    // 978-0-306-40615-7 -> 0-306-40615-2
+    const result = convertISBN13to10('9780306406157');
+    expect(result).toBe('0306406152');
+  });
+
+  it('should return null for non-978 prefix', () => {
+    // 979 prefix cannot be converted to ISBN-10
+    expect(convertISBN13to10('9791234567890')).toBe(null);
+  });
+
+  it('should return null for invalid length', () => {
+    expect(convertISBN13to10('12345')).toBe(null);
+  });
+});
+
+describe('formatISBNWithHyphens', () => {
+  let formatISBNWithHyphens: (isbn: string) => string;
+
+  beforeEach(() => {
+    formatISBNWithHyphens = createZotadataMethod('formatISBNWithHyphens');
+  });
+
+  it('should format ISBN-10 with hyphens', () => {
+    expect(formatISBNWithHyphens('0306406152')).toBe('0-30640-615-2');
+  });
+
+  it('should format ISBN-13 with hyphens', () => {
+    expect(formatISBNWithHyphens('9780306406157')).toBe('978-0-30640-615-7');
+  });
+
+  it('should return original for invalid input', () => {
+    expect(formatISBNWithHyphens('invalid')).toBe('invalid');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/isbn-convert.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/isbn-convert.test.ts
+git commit -m "test: add Tier 1 ISBN conversion tests"
+```
+
+---
+
+## Task 6: Tier 2 - API Clients Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/api-clients.test.ts`
+
+- [ ] **Step 1: Write API client tests with mocking**
+
+```typescript
+// tests/unit/zotadata/api-clients.test.ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { createMockHTTP, registerFixture } from '../../__mocks__/zotero-http';
+import { crossrefFixtures } from '../../__mocks__/fixtures/crossref';
+import { openalexFixtures } from '../../__mocks__/fixtures/openalex';
+
+describe('API Clients', () => {
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      Utilities: {
+        cleanDOI: (d: string) => d,
+      },
+      Date: {
+        strToDate: (d: string) => ({ year: d.match(/\d{4}/)?.[0] }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('searchCrossRefForDOI', () => {
+    let searchCrossRefForDOI: any;
+
+    beforeEach(() => {
+      searchCrossRefForDOI = createZotadataMethod('searchCrossRefForDOI', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should find DOI with matching title', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.singleWork);
+
+      const item = createMockItem({
+        title: 'Test Paper Title',
+        creators: [{ lastName: 'Smith' }],
+        date: '2023',
+      });
+
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should return null for no results', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.noResults);
+
+      const item = createMockItem({ title: 'Nonexistent Paper' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.serverError);
+
+      const item = createMockItem({ title: 'Test' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+
+    it('should handle rate limiting', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.rateLimited);
+
+      const item = createMockItem({ title: 'Test' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('fetchCrossRefMetadata', () => {
+    let fetchCrossRefMetadata: any;
+
+    beforeEach(() => {
+      fetchCrossRefMetadata = createZotadataMethod('fetchCrossRefMetadata');
+    });
+
+    it('should fetch and parse metadata', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.metadata);
+
+      const result = await fetchCrossRefMetadata('10.1000/test.doi');
+
+      expect(result).toMatchObject({
+        title: ['Full Metadata Paper'],
+        DOI: '10.1000/test.doi',
+        type: 'journal-article',
+      });
+    });
+  });
+
+  describe('searchCrossRefByArxivId', () => {
+    let searchCrossRefByArxivId: any;
+
+    beforeEach(() => {
+      searchCrossRefByArxivId = createZotadataMethod('searchCrossRefByArxivId');
+    });
+
+    it('should find published version by arXiv ID', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.arxivMatch);
+
+      const result = await searchCrossRefByArxivId('2301.12345');
+      expect(result).toBe('10.1000/published.doi');
+    });
+  });
+
+  describe('searchOpenAlexExact', () => {
+    let searchOpenAlexExact: any;
+
+    beforeEach(() => {
+      searchOpenAlexExact = createZotadataMethod('searchOpenAlexExact', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        extractDOI: createZotadataMethod('extractDOI'),
+      });
+    });
+
+    it('should find DOI with high similarity threshold', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.singleWork);
+
+      const item = createMockItem({
+        title: 'Test Paper Title',
+        DOI: '10.1000/test.doi',
+      });
+
+      const result = await searchOpenAlexExact(item, 'Test Paper Title');
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should return null for no results', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.noResults);
+
+      const item = createMockItem({ title: 'Nonexistent' });
+      const result = await searchOpenAlexExact(item, 'Nonexistent');
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('searchOpenAlexTitleOnly', () => {
+    let searchOpenAlexTitleOnly: any;
+
+    beforeEach(() => {
+      searchOpenAlexTitleOnly = createZotadataMethod('searchOpenAlexTitleOnly', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should search by title with 0.90 threshold', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.singleWork);
+
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchOpenAlexTitleOnly(item, 'Test Paper Title');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('searchSemanticScholarForDOI', () => {
+    let searchSemanticScholarForDOI: any;
+
+    beforeEach(() => {
+      searchSemanticScholarForDOI = createZotadataMethod('searchSemanticScholarForDOI', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should find DOI from Semantic Scholar', async () => {
+      const { semanticscholarFixtures } = await import('../../__mocks__/fixtures/semanticscholar');
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.singlePaper);
+
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchSemanticScholarForDOI(item);
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should filter arXiv venues', async () => {
+      const { semanticscholarFixtures } = await import('../../__mocks__/fixtures/semanticscholar');
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.arxivPaper);
+
+      const item = createMockItem({ title: 'arXiv Paper' });
+      const result = await searchSemanticScholarForDOI(item);
+      // Should return null since venue is arXiv
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('searchCrossRefForPublishedVersion', () => {
+    let searchCrossRefForPublishedVersion: any;
+
+    beforeEach(() => {
+      searchCrossRefForPublishedVersion = createZotadataMethod('searchCrossRefForPublishedVersion', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should exclude arXiv container from results', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.arxivMatch);
+
+      const item = createMockItem({ title: 'Published Version' });
+      const result = await searchCrossRefForPublishedVersion(item);
+      expect(result).toBeDefined();
+    });
+
+    it('should require 0.9 title similarity', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.singleWork);
+
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchCrossRefForPublishedVersion(item);
+      expect(result).toBeDefined();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/api-clients.test.ts`
+Expected: PASS (may need adjustments based on actual function signatures)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/api-clients.test.ts
+git commit -m "test: add Tier 2 API client tests with mocking"
+```
+
+---
+
+## Task 7: Tier 2 - Discovery Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/discovery.test.ts`
+
+- [ ] **Step 1: Write discovery orchestration tests**
+
+```typescript
+// tests/unit/zotadata/discovery.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { createMockHTTP } from '../../__mocks__/zotero-http';
+
+describe('discoverDOI', () => {
+  let discoverDOI: any;
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      Utilities: { cleanDOI: (d: string) => d },
+    };
+
+    // Create the method with mocked dependencies
+    discoverDOI = createZotadataMethod('discoverDOI', {
+      searchCrossRefForDOI: vi.fn().mockResolvedValue(null),
+      searchOpenAlexForDOI: vi.fn().mockResolvedValue(null),
+      searchSemanticScholarForDOI: vi.fn().mockResolvedValue(null),
+      searchDBLPForDOI: vi.fn().mockResolvedValue(null),
+      searchGoogleScholarForDOI: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('should return DOI from CrossRef if found', async () => {
+    discoverDOI = createZotadataMethod('discoverDOI', {
+      searchCrossRefForDOI: vi.fn().mockResolvedValue('10.1000/crossref.doi'),
+      searchOpenAlexForDOI: vi.fn().mockResolvedValue(null),
+    });
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await discoverDOI(item);
+    expect(result).toBe('10.1000/crossref.doi');
+  });
+
+  it('should fallback to OpenAlex if CrossRef fails', async () => {
+    discoverDOI = createZotadataMethod('discoverDOI', {
+      searchCrossRefForDOI: vi.fn().mockResolvedValue(null),
+      searchOpenAlexForDOI: vi.fn().mockResolvedValue('10.1000/openalex.doi'),
+    });
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await discoverDOI(item);
+    expect(result).toBe('10.1000/openalex.doi');
+  });
+
+  it('should return null if all sources fail', async () => {
+    const item = createMockItem({ title: 'Nonexistent Paper' });
+    const result = await discoverDOI(item);
+    expect(result).toBe(null);
+  });
+});
+
+describe('discoverISBN', () => {
+  let discoverISBN: any;
+
+  beforeEach(() => {
+    discoverISBN = createZotadataMethod('discoverISBN', {
+      searchOpenLibraryForISBN: vi.fn().mockResolvedValue(null),
+      searchGoogleBooksForISBN: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('should return ISBN from OpenLibrary if found', async () => {
+    discoverISBN = createZotadataMethod('discoverISBN', {
+      searchOpenLibraryForISBN: vi.fn().mockResolvedValue('9780123456789'),
+    });
+
+    const item = createMockItem({ title: 'Test Book' });
+    const result = await discoverISBN(item);
+    expect(result).toBe('9780123456789');
+  });
+
+  it('should fallback to Google Books if OpenLibrary fails', async () => {
+    discoverISBN = createZotadataMethod('discoverISBN', {
+      searchOpenLibraryForISBN: vi.fn().mockResolvedValue(null),
+      searchGoogleBooksForISBN: vi.fn().mockResolvedValue('9780123456789'),
+    });
+
+    const item = createMockItem({ title: 'Test Book' });
+    const result = await discoverISBN(item);
+    expect(result).toBe('9780123456789');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/discovery.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/discovery.test.ts
+git commit -m "test: add Tier 2 discovery orchestration tests"
+```
+
+---
+
+## Task 8: Tier 2 - Metadata Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/metadata.test.ts`
+
+- [ ] **Step 1: Write metadata tests**
+
+```typescript
+// tests/unit/zotadata/metadata.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { setupTranslateMock } from '../../__mocks__/zotero-translate';
+import { createMockHTTP, registerFixture } from '../../__mocks__/zotero-http';
+import { crossrefFixtures } from '../../__mocks__/fixtures/crossref';
+
+describe('fetchDOIBasedMetadata', () => {
+  let fetchDOIBasedMetadata: any;
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      Utilities: { cleanDOI: (d: string) => d },
+    };
+
+    fetchDOIBasedMetadata = createZotadataMethod('fetchDOIBasedMetadata', {
+      extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+      discoverDOI: vi.fn().mockResolvedValue('10.1000/discovered.doi'),
+      fetchCrossRefMetadata: vi.fn().mockResolvedValue({
+        title: ['Metadata Paper'],
+        DOI: '10.1000/test.doi',
+      }),
+      fetchDOIMetadataViaTranslator: vi.fn().mockResolvedValue({
+        title: 'Translator Metadata',
+      }),
+      updateItemWithMetadata: vi.fn(),
+    });
+  });
+
+  it('should use existing DOI if available', async () => {
+    registerFixture('crossref.org/works', crossrefFixtures.metadata);
+
+    const item = createMockItem({ DOI: '10.1000/test.doi' });
+    const result = await fetchDOIBasedMetadata(item);
+
+    expect(result).toBeDefined();
+    expect(result.DOI).toBe('10.1000/test.doi');
+  });
+
+  it('should discover DOI if not present', async () => {
+    const discoverDOI = vi.fn().mockResolvedValue('10.1000/discovered.doi');
+    fetchDOIBasedMetadata = createZotadataMethod('fetchDOIBasedMetadata', {
+      extractDOI: vi.fn().mockReturnValue(null),
+      discoverDOI,
+      fetchCrossRefMetadata: vi.fn().mockResolvedValue({ title: ['Found'] }),
+      updateItemWithMetadata: vi.fn(),
+    });
+
+    const item = createMockItem({ title: 'Paper Without DOI' });
+    await fetchDOIBasedMetadata(item);
+
+    expect(discoverDOI).toHaveBeenCalled();
+  });
+
+  it('should fallback to translator if API fails', async () => {
+    const fetchDOIMetadataViaTranslator = vi.fn().mockResolvedValue({
+      title: 'Translator Result',
+    });
+    fetchDOIBasedMetadata = createZotadataMethod('fetchDOIBasedMetadata', {
+      extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+      fetchCrossRefMetadata: vi.fn().mockResolvedValue(null),
+      fetchDOIMetadataViaTranslator,
+      updateItemWithMetadata: vi.fn(),
+    });
+
+    const item = createMockItem({ DOI: '10.1000/test.doi' });
+    await fetchDOIBasedMetadata(item);
+
+    expect(fetchDOIMetadataViaTranslator).toHaveBeenCalled();
+  });
+
+  it('should tag item on error', async () => {
+    fetchDOIBasedMetadata = createZotadataMethod('fetchDOIBasedMetadata', {
+      extractDOI: vi.fn().mockReturnValue(null),
+      discoverDOI: vi.fn().mockResolvedValue(null),
+    });
+
+    const item = createMockItem({ title: 'Unknown Paper' });
+    await fetchDOIBasedMetadata(item);
+
+    expect(item.addTag).toHaveBeenCalledWith('No DOI Found', 1);
+  });
+});
+
+describe('updateItemWithMetadata', () => {
+  let updateItemWithMetadata: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.ItemTypes = {
+      getID: vi.fn((type: string) => type === 'journalArticle' ? 1 : 2),
+    };
+    updateItemWithMetadata = createZotadataMethod('updateItemWithMetadata');
+  });
+
+  it('should update title field', async () => {
+    const item = createMockItem();
+    const metadata = { title: ['New Title'] };
+    await updateItemWithMetadata(item, metadata);
+    expect(item.setField).toHaveBeenCalledWith('title', 'New Title');
+  });
+
+  it('should update authors correctly', async () => {
+    const item = createMockItem();
+    const metadata = {
+      author: [
+        { given: 'John', family: 'Smith' },
+        { given: 'Jane', family: 'Doe' },
+      ],
+    };
+    await updateItemWithMetadata(item, metadata);
+    // Verify the item was updated (implementation depends on actual function)
+    expect(item.saveTx).toHaveBeenCalled();
+  });
+
+  it('should update volume/issue/pages', async () => {
+    const item = createMockItem();
+    const metadata = {
+      volume: '10',
+      issue: '2',
+      page: '123-145',
+    };
+    await updateItemWithMetadata(item, metadata);
+    expect(item.setField).toHaveBeenCalledWith('volume', '10');
+    expect(item.setField).toHaveBeenCalledWith('issue', '2');
+    expect(item.setField).toHaveBeenCalledWith('pages', '123-145');
+  });
+
+  it('should update URL from metadata', async () => {
+    const item = createMockItem();
+    const metadata = {
+      URL: 'https://doi.org/10.1000/test.doi',
+    };
+    await updateItemWithMetadata(item, metadata);
+    expect(item.setField).toHaveBeenCalledWith('url', 'https://doi.org/10.1000/test.doi');
+  });
+});
+
+describe('updateItemWithBookMetadata', () => {
+  let updateItemWithBookMetadata: any;
+
+  beforeEach(() => {
+    updateItemWithBookMetadata = createZotadataMethod('updateItemWithBookMetadata');
+  });
+
+  it('should update title and authors', async () => {
+    const item = createMockItem();
+    const metadata = {
+      title: 'Book Title',
+      authors: [{ name: 'John Smith' }],
+    };
+    await updateItemWithBookMetadata(item, metadata);
+    expect(item.setField).toHaveBeenCalledWith('title', 'Book Title');
+  });
+
+  it('should update publisher and date', async () => {
+    const item = createMockItem();
+    const metadata = {
+      publisher: 'Test Publisher',
+      publish_date: '2023',
+    };
+    await updateItemWithBookMetadata(item, metadata);
+    expect(item.setField).toHaveBeenCalledWith('publisher', 'Test Publisher');
+    expect(item.setField).toHaveBeenCalledWith('date', '2023');
+  });
+});
+
+describe('fetchBookMetadataViaTranslator', () => {
+  let fetchBookMetadataViaTranslator: any;
+
+  beforeEach(() => {
+    fetchBookMetadataViaTranslator = createZotadataMethod('fetchBookMetadataViaTranslator');
+  });
+
+  it('should use translator when available', async () => {
+    setupTranslateMock({
+      found: true,
+      item: { title: 'Test Book', creators: [] },
+    });
+
+    const item = createMockItem({ ISBN: '9780123456789' });
+    const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+    expect(result).toBeDefined();
+  });
+
+  it('should return null if no translator found', async () => {
+    setupTranslateMock({ found: false });
+
+    const item = createMockItem({ ISBN: '9780123456789' });
+    const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('fetchDOIMetadataViaTranslator', () => {
+  let fetchDOIMetadataViaTranslator: any;
+
+  beforeEach(() => {
+    fetchDOIMetadataViaTranslator = createZotadataMethod('fetchDOIMetadataViaTranslator');
+  });
+
+  it('should fetch metadata via translator', async () => {
+    setupTranslateMock({
+      found: true,
+      item: { title: 'DOI Paper', DOI: '10.1000/test.doi' },
+    });
+
+    const item = createMockItem({ DOI: '10.1000/test.doi' });
+    const result = await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+    expect(result).toBeDefined();
+  });
+
+  it('should apply fields to item', async () => {
+    const item = createMockItem();
+    setupTranslateMock({
+      found: true,
+      item: { title: 'New Title', DOI: '10.1000/test.doi' },
+    });
+
+    await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+    // Verify item was updated
+  });
+});
+
+describe('tryAlternativeISBNFormats', () => {
+  let tryAlternativeISBNFormats: any;
+
+  beforeEach(() => {
+    tryAlternativeISBNFormats = createZotadataMethod('tryAlternativeISBNFormats', {
+      convertISBN10to13: createZotadataMethod('convertISBN10to13'),
+      convertISBN13to10: createZotadataMethod('convertISBN13to10'),
+      fetchBookMetadataViaTranslator: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('should try ISBN-10 to ISBN-13 conversion', async () => {
+    const fetchBook = vi.fn()
+      .mockResolvedValueOnce(null)  // original ISBN
+      .mockResolvedValueOnce({ title: 'Found with ISBN-13' });  // converted ISBN-13
+
+    tryAlternativeISBNFormats = createZotadataMethod('tryAlternativeISBNFormats', {
+      convertISBN10to13: vi.fn().mockReturnValue('9780123456789'),
+      convertISBN13to10: vi.fn().mockReturnValue(null),
+      fetchBookMetadataViaTranslator: fetchBook,
+    });
+
+    const item = createMockItem();
+    await tryAlternativeISBNFormats('0123456789', item);
+
+    expect(fetchBook).toHaveBeenCalledTimes(2);
+  });
+
+  it('should try ISBN-13 to ISBN-10 conversion', async () => {
+    const fetchBook = vi.fn()
+      .mockResolvedValueOnce(null)  // original ISBN-13
+      .mockResolvedValueOnce({ title: 'Found with ISBN-10' });  // converted ISBN-10
+
+    tryAlternativeISBNFormats = createZotadataMethod('tryAlternativeISBNFormats', {
+      convertISBN10to13: vi.fn().mockReturnValue(null),
+      convertISBN13to10: vi.fn().mockReturnValue('0123456789'),
+      fetchBookMetadataViaTranslator: fetchBook,
+    });
+
+    const item = createMockItem();
+    await tryAlternativeISBNFormats('9780123456789', item);
+
+    expect(fetchBook).toHaveBeenCalled();
+  });
+
+  it('should return null when all formats fail', async () => {
+    const item = createMockItem();
+    const result = await tryAlternativeISBNFormats('0000000000', item);
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement and run tests**
+
+Run: `npm test tests/unit/zotadata/metadata.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/metadata.test.ts
+git commit -m "test: add Tier 2 metadata tests"
+```
+
+---
+
+## Task 9: Tier 2 - arXiv Processing Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/arxiv-processing.test.ts`
+
+- [ ] **Step 1: Write arXiv processing tests**
+
+```typescript
+// tests/unit/zotadata/arxiv-processing.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+
+describe('processArxivItem', () => {
+  let processArxivItem: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.ItemTypes = {
+      getID: vi.fn((type: string) => type === 'journalArticle' ? 1 : 2),
+      getName: vi.fn((id: number) => id === 1 ? 'journalArticle' : 'preprint'),
+    };
+  });
+
+  it('should find published version for arXiv item', async () => {
+    const findPublishedVersion = vi.fn().mockResolvedValue('10.1000/published.doi');
+    const updateItemAsPublishedVersion = vi.fn().mockResolvedValue(undefined);
+    const downloadPublishedVersion = vi.fn().mockResolvedValue(undefined);
+    const itemHasPDF = vi.fn().mockResolvedValue(false);
+
+    processArxivItem = createZotadataMethod('processArxivItem', {
+      isArxivItem: vi.fn().mockReturnValue(true),
+      findPublishedVersion,
+      updateItemAsPublishedVersion,
+      downloadPublishedVersion,
+      itemHasPDF,
+    });
+
+    const item = createMockItem({ title: 'arXiv Paper' });
+    const result = await processArxivItem(item);
+
+    expect(result.foundPublished).toBe(true);
+    expect(findPublishedVersion).toHaveBeenCalled();
+  });
+
+  it('should convert to preprint if no published version', async () => {
+    const convertToPreprint = vi.fn().mockResolvedValue(undefined);
+
+    processArxivItem = createZotadataMethod('processArxivItem', {
+      isArxivItem: vi.fn().mockReturnValue(true),
+      findPublishedVersion: vi.fn().mockResolvedValue(null),
+      convertToPreprint,
+    });
+
+    const item = createMockItem({ title: 'arXiv Paper' });
+    const result = await processArxivItem(item);
+
+    expect(result.converted).toBe(true);
+    expect(convertToPreprint).toHaveBeenCalled();
+  });
+
+  it('should skip non-arXiv items', async () => {
+    processArxivItem = createZotadataMethod('processArxivItem', {
+      isArxivItem: vi.fn().mockReturnValue(false),
+    });
+
+    const item = createMockItem({ title: 'Regular Paper' });
+    const result = await processArxivItem(item);
+
+    expect(result.processed).toBe(false);
+  });
+
+  it('should tag items on error', async () => {
+    processArxivItem = createZotadataMethod('processArxivItem', {
+      isArxivItem: vi.fn().mockReturnValue(true),
+      findPublishedVersion: vi.fn().mockRejectedValue(new Error('API Error')),
+    });
+
+    const item = createMockItem({ title: 'arXiv Paper' });
+    await processArxivItem(item);
+
+    expect(item.addTag).toHaveBeenCalled();
+  });
+});
+
+describe('findPublishedVersion', () => {
+  let findPublishedVersion: any;
+
+  beforeEach(() => {
+    findPublishedVersion = createZotadataMethod('findPublishedVersion', {
+      extractArxivId: vi.fn().mockReturnValue('2301.12345'),
+      searchCrossRefByArxivId: vi.fn().mockResolvedValue(null),
+      searchCrossRefForPublishedVersion: vi.fn().mockResolvedValue(null),
+      searchSemanticScholarForPublishedVersion: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('should search by arXiv ID first', async () => {
+    const searchCrossRefByArxivId = vi.fn().mockResolvedValue('10.1000/published.doi');
+    findPublishedVersion = createZotadataMethod('findPublishedVersion', {
+      extractArxivId: vi.fn().mockReturnValue('2301.12345'),
+      searchCrossRefByArxivId,
+    });
+
+    const item = createMockItem({ title: 'arXiv Paper' });
+    const result = await findPublishedVersion(item);
+
+    expect(searchCrossRefByArxivId).toHaveBeenCalledWith('2301.12345');
+    expect(result).toBe('10.1000/published.doi');
+  });
+
+  it('should fallback to title search', async () => {
+    const searchCrossRefForPublishedVersion = vi.fn().mockResolvedValue('10.1000/title.doi');
+    findPublishedVersion = createZotadataMethod('findPublishedVersion', {
+      extractArxivId: vi.fn().mockReturnValue('2301.12345'),
+      searchCrossRefByArxivId: vi.fn().mockResolvedValue(null),
+      searchCrossRefForPublishedVersion,
+    });
+
+    const item = createMockItem({ title: 'arXiv Paper' });
+    const result = await findPublishedVersion(item);
+
+    expect(searchCrossRefForPublishedVersion).toHaveBeenCalled();
+    expect(result).toBe('10.1000/title.doi');
+  });
+
+  it('should return null if no published version found', async () => {
+    const item = createMockItem({ title: 'arXiv Paper' });
+    const result = await findPublishedVersion(item);
+    expect(result).toBeNull();
+  });
+});
+
+describe('convertToPreprint', () => {
+  let convertToPreprint: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.ItemTypes = {
+      getID: vi.fn((type: string) => type === 'preprint' ? 4 : null),
+    };
+    convertToPreprint = createZotadataMethod('convertToPreprint');
+  });
+
+  it('should change item type to preprint', async () => {
+    const item = createMockItem();
+    await convertToPreprint(item);
+    expect(item.setType).toHaveBeenCalled();
+  });
+
+  it('should set repository field to arXiv', async () => {
+    const item = createMockItem();
+    await convertToPreprint(item);
+    expect(item.setField).toHaveBeenCalledWith('repository', 'arXiv');
+  });
+
+  it('should clear publication title', async () => {
+    const item = createMockItem();
+    await convertToPreprint(item);
+    expect(item.setField).toHaveBeenCalledWith('publicationTitle', '');
+  });
+
+  it('should add Converted to Preprint tag', async () => {
+    const item = createMockItem();
+    await convertToPreprint(item);
+    expect(item.addTag).toHaveBeenCalledWith('Converted to Preprint', 1);
+  });
+});
+
+describe('updateItemAsPublishedVersion', () => {
+  let updateItemAsPublishedVersion: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.ItemTypes = {
+      getID: vi.fn((type: string) => type === 'journalArticle' ? 1 : 3),
+      getName: vi.fn((id: number) => id === 1 ? 'journalArticle' : 'conferencePaper'),
+    };
+    updateItemAsPublishedVersion = createZotadataMethod('updateItemAsPublishedVersion', {
+      fetchDOIMetadataViaTranslator: vi.fn().mockResolvedValue(null),
+      updateItemWithMetadata: vi.fn(),
+    });
+  });
+
+  it('should convert VENUE: format to conferencePaper', async () => {
+    const item = createMockItem();
+    await updateItemAsPublishedVersion(item, 'VENUE:NeurIPS 2023');
+
+    expect(item.setType).toHaveBeenCalled();
+    expect(item.setField).toHaveBeenCalledWith('conferenceName', 'NeurIPS 2023');
+  });
+
+  it('should convert DOI format to journalArticle', async () => {
+    const item = createMockItem();
+    await updateItemAsPublishedVersion(item, '10.1000/published.doi');
+
+    expect(item.setField).toHaveBeenCalledWith('DOI', '10.1000/published.doi');
+  });
+});
+
+describe('searchSemanticScholarForPublishedVersion', () => {
+  let searchSemanticScholarForPublishedVersion: any;
+
+  beforeEach(() => {
+    searchSemanticScholarForPublishedVersion = createZotadataMethod('searchSemanticScholarForPublishedVersion', {
+      titleSimilarity: createZotadataMethod('titleSimilarity'),
+    });
+  });
+
+  it('should exclude arXiv venue from results', async () => {
+    // Mock response with arXiv venue - should be filtered out
+    const mockHTTP = {
+      request: vi.fn().mockResolvedValue({
+        status: 200,
+        responseText: JSON.stringify({
+          data: [{
+            paperId: 'arxiv123',
+            title: 'Test Paper',
+            venue: 'arXiv', // Should be excluded
+            year: 2023,
+            externalIds: { DOI: '10.1000/arxiv.doi' },
+          }],
+        }),
+      }),
+    };
+    (globalThis as any).Zotero.HTTP = mockHTTP;
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await searchSemanticScholarForPublishedVersion(item);
+
+    // Should return null since arXiv venue is excluded
+    expect(result).toBeNull();
+  });
+
+  it('should require similarity threshold', async () => {
+    const mockHTTP = {
+      request: vi.fn().mockResolvedValue({
+        status: 200,
+        responseText: JSON.stringify({
+          data: [{
+            paperId: 'pub123',
+            title: 'Completely Different Title', // Low similarity
+            venue: 'Nature',
+            year: 2023,
+            externalIds: { DOI: '10.1000/pub.doi' },
+          }],
+        }),
+      }),
+    };
+    (globalThis as any).Zotero.HTTP = mockHTTP;
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await searchSemanticScholarForPublishedVersion(item);
+
+    // Should return null due to low similarity
+    expect(result).toBeNull();
+  });
+
+  it('should extract DOI from result', async () => {
+    const mockHTTP = {
+      request: vi.fn().mockResolvedValue({
+        status: 200,
+        responseText: JSON.stringify({
+          data: [{
+            paperId: 'pub123',
+            title: 'Test Paper', // High similarity
+            venue: 'Nature',
+            year: 2024,
+            externalIds: { DOI: '10.1000/published.doi' },
+          }],
+        }),
+      }),
+    };
+    (globalThis as any).Zotero.HTTP = mockHTTP;
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await searchSemanticScholarForPublishedVersion(item);
+
+    expect(result).toBe('10.1000/published.doi');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/arxiv-processing.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/arxiv-processing.test.ts
+git commit -m "test: add Tier 2 arXiv processing tests"
+```
+
+---
+
+## Task 10: Tier 2-3 - File Operations Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/file-operations.test.ts`
+
+- [ ] **Step 1: Write file operations tests**
+
+```typescript
+// tests/unit/zotadata/file-operations.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem, createMockAttachment } from '../../__mocks__/zotero-items';
+import { createMockHTTP, registerFixture } from '../../__mocks__/zotero-http';
+
+describe('itemHasPDF', () => {
+  let itemHasPDF: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.Items = {
+      get: vi.fn(),
+    };
+    itemHasPDF = createZotadataMethod('itemHasPDF');
+  });
+
+  it('should return true for item with PDF attachment', async () => {
+    const attachment = createMockAttachment({
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: true,
+    });
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(attachment);
+
+    const result = await itemHasPDF(item);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for item without attachments', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([]);
+
+    const result = await itemHasPDF(item);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for item with broken attachment', async () => {
+    const attachment = createMockAttachment({
+      linkMode: 2,
+      fileExists: false,
+    });
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(attachment);
+
+    const result = await itemHasPDF(item);
+    expect(result).toBe(false);
+  });
+});
+
+describe('verifyStoredAttachment', () => {
+  let verifyStoredAttachment: any;
+
+  beforeEach(() => {
+    verifyStoredAttachment = createZotadataMethod('verifyStoredAttachment');
+  });
+
+  it('should return true for stored file', () => {
+    const attachment = createMockAttachment({
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: true,
+    });
+
+    const result = verifyStoredAttachment(attachment);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for linked file', () => {
+    const attachment = createMockAttachment({
+      linkMode: 3, // LINKED_FILE
+    });
+
+    const result = verifyStoredAttachment(attachment);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for URL link', () => {
+    const attachment = createMockAttachment({
+      linkMode: 1, // LINKED_URL
+    });
+
+    const result = verifyStoredAttachment(attachment);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for invalid attachment', () => {
+    const result = verifyStoredAttachment(null);
+    expect(result).toBe(false);
+  });
+});
+
+describe('findUnpaywallPDF', () => {
+  let findUnpaywallPDF: any;
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+    };
+    findUnpaywallPDF = createZotadataMethod('findUnpaywallPDF');
+  });
+
+  it('should find open access PDF', async () => {
+    registerFixture('api.unpaywall.org', {
+      status: 200,
+      responseText: JSON.stringify({
+        is_oa: true,
+        best_oa_location: {
+          url_for_pdf: 'https://example.com/paper.pdf',
+          host_type: 'publisher',
+        },
+      }),
+      getResponseHeader: () => null,
+    });
+
+    const result = await findUnpaywallPDF('10.1000/test.doi', 'test@example.com');
+    expect(result).toBe('https://example.com/paper.pdf');
+  });
+
+  it('should return null if no OA PDF', async () => {
+    registerFixture('api.unpaywall.org', {
+      status: 200,
+      responseText: JSON.stringify({
+        is_oa: false,
+      }),
+      getResponseHeader: () => null,
+    });
+
+    const result = await findUnpaywallPDF('10.1000/test.doi', 'test@example.com');
+    expect(result).toBeNull();
+  });
+
+  it('should include email in request', async () => {
+    mockHTTP.request = vi.fn().mockResolvedValue({
+      status: 200,
+      responseText: JSON.stringify({ is_oa: false }),
+    });
+
+    await findUnpaywallPDF('10.1000/test.doi', 'test@example.com');
+
+    expect(mockHTTP.request).toHaveBeenCalled();
+    const call = mockHTTP.request.mock.calls[0];
+    expect(call[1]).toContain('test@example.com');
+  });
+
+  it('should handle HTTP error gracefully', async () => {
+    registerFixture('api.unpaywall.org', {
+      status: 500,
+      responseText: '{}',
+      getResponseHeader: () => null,
+    });
+
+    const result = await findUnpaywallPDF('10.1000/test.doi', 'test@example.com');
+    expect(result).toBeNull();
+  });
+});
+
+describe('findCorePDFByDOI', () => {
+  let findCorePDFByDOI: any;
+
+  beforeEach(() => {
+    findCorePDFByDOI = createZotadataMethod('findCorePDFByDOI');
+  });
+
+  it('should find PDF with downloadUrl', async () => {
+    registerFixture('api.core.ac.uk', {
+      status: 200,
+      responseText: JSON.stringify({
+        data: [{
+          downloadUrl: 'https://core.ac.uk/paper.pdf',
+        }],
+      }),
+      getResponseHeader: () => null,
+    });
+
+    const result = await findCorePDFByDOI('10.1000/test.doi');
+    expect(result).toBe('https://core.ac.uk/paper.pdf');
+  });
+
+  it('should return null for no results', async () => {
+    registerFixture('api.core.ac.uk', {
+      status: 200,
+      responseText: JSON.stringify({ data: [] }),
+      getResponseHeader: () => null,
+    });
+
+    const result = await findCorePDFByDOI('10.1000/test.doi');
+    expect(result).toBeNull();
+  });
+
+  it('should handle HTTP error', async () => {
+    registerFixture('api.core.ac.uk', {
+      status: 500,
+      responseText: '{}',
+      getResponseHeader: () => null,
+    });
+
+    const result = await findCorePDFByDOI('10.1000/test.doi');
+    expect(result).toBeNull();
+  });
+});
+
+describe('findArxivPDF', () => {
+  let findArxivPDF: any;
+
+  beforeEach(() => {
+    findArxivPDF = createZotadataMethod('findArxivPDF', {
+      extractArxivId: createZotadataMethod('extractArxivId'),
+    });
+  });
+
+  it('should find PDF by arXiv ID', async () => {
+    findArxivPDF = createZotadataMethod('findArxivPDF', {
+      extractArxivId: vi.fn().mockReturnValue('2301.12345'),
+    });
+
+    const item = createMockItem({ extra: 'arXiv:2301.12345' });
+    const result = await findArxivPDF(item);
+    expect(result).toBe('https://arxiv.org/pdf/2301.12345.pdf');
+  });
+
+  it('should search by title if no arXiv ID', async () => {
+    findArxivPDF = createZotadataMethod('findArxivPDF', {
+      extractArxivId: vi.fn().mockReturnValue(null),
+    });
+
+    const item = createMockItem({ title: 'Test Paper' });
+    const result = await findArxivPDF(item);
+    // Result depends on whether paper is found in arXiv search
+    expect(result).toBeDefined();
+  });
+
+  it('should return null if no match found', async () => {
+    findArxivPDF = createZotadataMethod('findArxivPDF', {
+      extractArxivId: vi.fn().mockReturnValue(null),
+    });
+
+    const item = createMockItem({ title: 'Nonexistent Paper' });
+    const result = await findArxivPDF(item);
+    expect(result).toBeNull();
+  });
+});
+
+describe('findFileForItem', () => {
+  let findFileForItem: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero.ItemTypes = {
+      getName: vi.fn((id: number) => id === 1 ? 'journalArticle' : 'book'),
+    };
+    findFileForItem = createZotadataMethod('findFileForItem', {
+      extractDOI: createZotadataMethod('extractDOI'),
+      extractISBN: createZotadataMethod('extractISBN'),
+      extractArxivId: createZotadataMethod('extractArxivId'),
+      isArxivItem: vi.fn().mockReturnValue(false),
+    });
+  });
+
+  it('should search ISBN sources for books', async () => {
+    const item = createMockItem({ itemTypeID: 2 }); // book type
+    item.getField = vi.fn((field: string) => {
+      if (field === 'ISBN') return '9780123456789';
+      return '';
+    });
+
+    const result = await findFileForItem(item);
+    expect(result).toBeDefined();
+    expect(result.source).toBeDefined();
+  });
+
+  it('should search DOI sources for articles', async () => {
+    const item = createMockItem({ itemTypeID: 1, DOI: '10.1000/test.doi' });
+
+    const result = await findFileForItem(item);
+    expect(result).toBeDefined();
+  });
+
+  it('should search arXiv for preprints', async () => {
+    findFileForItem = createZotadataMethod('findFileForItem', {
+      extractDOI: vi.fn().mockReturnValue(null),
+      extractISBN: vi.fn().mockReturnValue(null),
+      extractArxivId: vi.fn().mockReturnValue('2301.12345'),
+      isArxivItem: vi.fn().mockReturnValue(true),
+      findArxivPDF: vi.fn().mockResolvedValue('https://arxiv.org/pdf/2301.12345.pdf'),
+    });
+
+    const item = createMockItem({ itemTypeID: 1 });
+    const result = await findFileForItem(item);
+    expect(result.url).toBeDefined();
+  });
+});
+
+describe('findPublishedPDF', () => {
+  let findPublishedPDF: any;
+
+  beforeEach(() => {
+    findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+      findUnpaywallPDF: vi.fn().mockResolvedValue(null),
+      findCorePDFByDOI: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('should find PDF via Unpaywall first', async () => {
+    findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+      findUnpaywallPDF: vi.fn().mockResolvedValue('https://unpaywall.org/paper.pdf'),
+    });
+
+    const result = await findPublishedPDF('10.1000/test.doi');
+    expect(result).toBe('https://unpaywall.org/paper.pdf');
+  });
+
+  it('should fallback to CORE if Unpaywall fails', async () => {
+    findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+      findUnpaywallPDF: vi.fn().mockResolvedValue(null),
+      findCorePDFByDOI: vi.fn().mockResolvedValue('https://core.ac.uk/paper.pdf'),
+    });
+
+    const result = await findPublishedPDF('10.1000/test.doi');
+    expect(result).toBe('https://core.ac.uk/paper.pdf');
+  });
+
+  it('should return null if no PDF found', async () => {
+    const result = await findPublishedPDF('10.1000/nonexistent.doi');
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/file-operations.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/file-operations.test.ts
+git commit -m "test: add Tier 2-3 file operations tests"
+```
+
+---
+
+## Task 11: Tier 3 - Batch Processing Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/batch-processing.test.ts`
+
+- [ ] **Step 1: Write batch processing tests**
+
+```typescript
+// tests/unit/zotadata/batch-processing.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem, createMockAttachment } from '../../__mocks__/zotero-items';
+
+describe('processBatch', () => {
+  let processBatch: any;
+
+  beforeEach(() => {
+    processBatch = createZotadataMethod('processBatch');
+  });
+
+  it('should process items in batches', async () => {
+    const items = Array(10).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await processBatch(items, processFn, { batchSize: 3 });
+
+    expect(result.totalProcessed).toBe(10);
+    expect(result.success).toBe(true);
+  });
+
+  it('should handle errors in processing', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const processFn = vi.fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Failed'));
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result.errorCount).toBe(1);
+  });
+
+  it('should call progress callback', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const progressCallback = vi.fn();
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, {
+      batchSize: 1,
+      progressCallback,
+    });
+
+    expect(progressCallback).toHaveBeenCalled();
+  });
+
+  it('should respect batch size setting', async () => {
+    const items = Array(6).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, { batchSize: 2 });
+
+    // Verify processFn was called for all items
+    expect(processFn).toHaveBeenCalledTimes(6);
+  });
+
+  it('should add delay between batches', async () => {
+    const items = Array(4).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+    const delayBetweenBatches = 50;
+
+    const start = Date.now();
+    await processBatch(items, processFn, { batchSize: 2, delayBetweenBatches });
+    const duration = Date.now() - start;
+
+    // Should have at least one delay between batches
+    expect(duration).toBeGreaterThanOrEqual(delayBetweenBatches - 10); // Allow small margin
+  });
+
+  it('should return correct result structure', async () => {
+    const items = [createMockItem({ id: 1 })];
+    const processFn = vi.fn().mockResolvedValue({ data: 'test' });
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result).toHaveProperty('success');
+    expect(result).toHaveProperty('totalProcessed');
+    expect(result).toHaveProperty('errorCount');
+    expect(result).toHaveProperty('results');
+    expect(Array.isArray(result.results)).toBe(true);
+  });
+
+  it('should collect errors without stopping batch', async () => {
+    const items = Array(3).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Failed'))
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.errorCount).toBe(1);
+    expect(result.totalProcessed).toBe(3);
+  });
+});
+
+describe('simpleAttachmentCheckBatch', () => {
+  let simpleAttachmentCheckBatch: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      Attachments: {
+        LINK_MODE_LINKED_URL: 1,
+        LINK_MODE_IMPORTED_FILE: 2,
+        LINK_MODE_LINKED_FILE: 3,
+      },
+      Items: {
+        get: vi.fn(),
+      },
+    };
+    simpleAttachmentCheckBatch = createZotadataMethod('simpleAttachmentCheckBatch');
+  });
+
+  it('should return stats for item with no attachments', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([]);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.weblinks).toBe(0);
+    expect(result.processed).toBe(1);
+  });
+
+  it('should remove broken file attachments', async () => {
+    const brokenAttachment = createMockAttachment({
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: false,
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(brokenAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.removed).toBe(1);
+    expect(brokenAttachment.eraseTx).toHaveBeenCalled();
+  });
+
+  it('should keep weblink attachments', async () => {
+    const weblinkAttachment = createMockAttachment({
+      linkMode: 1, // LINKED_URL
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(weblinkAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.weblinks).toBe(1);
+    expect(result.valid).toBe(1);
+    expect(weblinkAttachment.eraseTx).not.toHaveBeenCalled();
+  });
+
+  it('should count valid file attachments', async () => {
+    const validAttachment = createMockAttachment({
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: true,
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(validAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(1);
+    expect(result.removed).toBe(0);
+  });
+
+  it('should handle errors gracefully', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockImplementation(() => {
+      throw new Error('Test error');
+    });
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.errors).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/batch-processing.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/batch-processing.test.ts
+git commit -m "test: add Tier 3 batch processing tests"
+```
+
+---
+
+## Task 12: Tier 3 - Integration Tests
+
+**Files:**
+- Create: `tests/unit/zotadata/integration.test.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+```typescript
+// tests/unit/zotadata/integration.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { createMockHTTP } from '../../__mocks__/zotero-http';
+
+// Mock Zotero pane
+const createMockPane = (items: any[]) => ({
+  getSelectedItems: vi.fn().mockReturnValue(items),
+});
+
+describe('fetchMetadataForSelectedItems', () => {
+  let fetchMetadataForSelectedItems: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      getActiveZoteroPane: vi.fn(),
+      ItemTypes: {
+        getName: vi.fn((id: number) => id === 1 ? 'journalArticle' : 'book'),
+      },
+    };
+    fetchMetadataForSelectedItems = createZotadataMethod('fetchMetadataForSelectedItems', {
+      processBatch: createZotadataMethod('processBatch'),
+      fetchItemMetadata: vi.fn().mockResolvedValue({ success: true }),
+    });
+  });
+
+  it('should process selected items in batch', async () => {
+    const items = [
+      createMockItem({ id: 1, title: 'Paper 1' }),
+      createMockItem({ id: 2, title: 'Paper 2' }),
+    ];
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    const result = await fetchMetadataForSelectedItems();
+
+    expect(result).toBeDefined();
+  });
+
+  it('should filter for supported item types', async () => {
+    const items = [
+      createMockItem({ id: 1, itemTypeID: 1 }), // journalArticle
+      createMockItem({ id: 2, itemTypeID: 99 }), // unsupported
+    ];
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await fetchMetadataForSelectedItems();
+
+    // Only supported items should be processed
+  });
+
+  it('should show summary after completion', async () => {
+    const items = [createMockItem({ id: 1 })];
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    const showDialog = vi.fn();
+    fetchMetadataForSelectedItems = createZotadataMethod('fetchMetadataForSelectedItems', {
+      processBatch: vi.fn().mockResolvedValue({
+        success: true,
+        totalProcessed: 1,
+        results: [{ result: { success: true } }],
+      }),
+      fetchItemMetadata: vi.fn().mockResolvedValue({ success: true }),
+      showDialog,
+    });
+
+    await fetchMetadataForSelectedItems();
+
+    expect(showDialog).toHaveBeenCalled();
+  });
+
+  it('should handle empty selection', async () => {
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane([]));
+
+    await fetchMetadataForSelectedItems();
+
+    // Should show message about no selection
+  });
+});
+
+describe('processArxivItems', () => {
+  let processArxivItems: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      getActiveZoteroPane: vi.fn(),
+      ItemTypes: {
+        getName: vi.fn((id: number) => {
+          const types: Record<number, string> = {
+            1: 'journalArticle',
+            2: 'preprint',
+            3: 'conferencePaper',
+          };
+          return types[id] || 'unknown';
+        }),
+      },
+    };
+    processArxivItems = createZotadataMethod('processArxivItems', {
+      processBatch: createZotadataMethod('processBatch'),
+      isArxivItem: vi.fn().mockReturnValue(false),
+      extractDOI: vi.fn().mockReturnValue(null),
+    });
+  });
+
+  it('should filter for arXiv candidates', async () => {
+    const arxivItem = createMockItem({ id: 1 });
+    const regularItem = createMockItem({ id: 2 });
+
+    processArxivItems = createZotadataMethod('processArxivItems', {
+      processBatch: vi.fn().mockResolvedValue({ success: true, results: [] }),
+      isArxivItem: vi.fn().mockImplementation((item: any) => item.id === 1),
+      extractDOI: vi.fn().mockReturnValue(null),
+    });
+
+    const items = [arxivItem, regularItem];
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await processArxivItems();
+
+    // Only arXiv candidates should be processed
+  });
+
+  it('should aggregate statistics', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+
+    processArxivItems = createZotadataMethod('processArxivItems', {
+      processBatch: vi.fn().mockResolvedValue({
+        success: true,
+        totalProcessed: 2,
+        results: [
+          { result: { converted: true, foundPublished: false } },
+          { result: { converted: false, foundPublished: true } },
+        ],
+      }),
+      isArxivItem: vi.fn().mockReturnValue(true),
+      extractDOI: vi.fn().mockReturnValue(null),
+      showGenericBatchSummary: vi.fn(),
+    });
+
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await processArxivItems();
+
+    // Should aggregate converted/foundPublished counts
+  });
+});
+
+describe('findSelectedFiles', () => {
+  let findSelectedFiles: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      getActiveZoteroPane: vi.fn(),
+      ItemTypes: {
+        getName: vi.fn((id: number) => id === 1 ? 'journalArticle' : 'book'),
+      },
+    };
+    findSelectedFiles = createZotadataMethod('findSelectedFiles', {
+      processBatch: createZotadataMethod('processBatch'),
+      itemHasPDF: vi.fn().mockResolvedValue(false),
+      findFileForItem: vi.fn().mockResolvedValue({ url: null, source: null }),
+    });
+  });
+
+  it('should find items needing files', async () => {
+    const items = [
+      createMockItem({ id: 1, itemTypeID: 1 }),
+      createMockItem({ id: 2, itemTypeID: 1 }),
+    ];
+
+    findSelectedFiles = createZotadataMethod('findSelectedFiles', {
+      processBatch: vi.fn().mockResolvedValue({
+        success: true,
+        totalProcessed: 2,
+        results: [],
+      }),
+      itemHasPDF: vi.fn().mockResolvedValue(false),
+    });
+
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await findSelectedFiles();
+
+    // Items without PDFs should be identified
+  });
+
+  it('should attempt download for found URLs', async () => {
+    const item = createMockItem({ id: 1, itemTypeID: 1 });
+
+    findSelectedFiles = createZotadataMethod('findSelectedFiles', {
+      processBatch: vi.fn().mockResolvedValue({
+        success: true,
+        results: [{ result: { found: true, downloaded: true } }],
+      }),
+      itemHasPDF: vi.fn().mockResolvedValue(false),
+      findFileForItem: vi.fn().mockResolvedValue({
+        url: 'https://example.com/paper.pdf',
+        source: 'unpaywall',
+      }),
+      downloadFileForItem: vi.fn().mockResolvedValue(true),
+    });
+
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane([item]));
+
+    await findSelectedFiles();
+
+    // Download should be attempted
+  });
+});
+
+describe('checkSelectedItems', () => {
+  let checkSelectedItems: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      getActiveZoteroPane: vi.fn(),
+    };
+    checkSelectedItems = createZotadataMethod('checkSelectedItems', {
+      processBatch: createZotadataMethod('processBatch'),
+      simpleAttachmentCheckBatch: vi.fn().mockResolvedValue({
+        valid: 1,
+        removed: 0,
+        weblinks: 0,
+      }),
+    });
+  });
+
+  it('should validate attachments in batch', async () => {
+    const items = [createMockItem({ id: 1 })];
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await checkSelectedItems();
+
+    // Attachments should be validated
+  });
+
+  it('should aggregate statistics', async () => {
+    const items = [
+      createMockItem({ id: 1 }),
+      createMockItem({ id: 2 }),
+    ];
+
+    checkSelectedItems = createZotadataMethod('checkSelectedItems', {
+      processBatch: vi.fn().mockResolvedValue({
+        success: true,
+        totalProcessed: 2,
+        results: [
+          { result: { valid: 1, removed: 1, weblinks: 0 } },
+          { result: { valid: 2, removed: 0, weblinks: 1 } },
+        ],
+      }),
+      showBatchSummary: vi.fn(),
+    });
+
+    (globalThis as any).Zotero.getActiveZoteroPane = vi.fn().mockReturnValue(createMockPane(items));
+
+    await checkSelectedItems();
+
+    // Statistics should be aggregated
+  });
+});
+
+describe('fetchItemMetadata', () => {
+  let fetchItemMetadata: any;
+
+  beforeEach(() => {
+    (globalThis as any).Zotero = {
+      ItemTypes: {
+        getName: vi.fn((id: number) => {
+          const types: Record<number, string> = {
+            1: 'journalArticle',
+            2: 'book',
+            99: 'annotation',
+          };
+          return types[id] || 'unknown';
+        }),
+      },
+    };
+    fetchItemMetadata = createZotadataMethod('fetchItemMetadata', {
+      fetchDOIBasedMetadata: vi.fn().mockResolvedValue({ success: true }),
+      fetchISBNBasedMetadata: vi.fn().mockResolvedValue({ success: true }),
+    });
+  });
+
+  it('should use DOI path for journal articles', async () => {
+    const fetchDOIBasedMetadata = vi.fn().mockResolvedValue({ success: true });
+    fetchItemMetadata = createZotadataMethod('fetchItemMetadata', {
+      fetchDOIBasedMetadata,
+    });
+
+    const item = createMockItem({ id: 1, itemTypeID: 1 });
+    await fetchItemMetadata(item);
+
+    expect(fetchDOIBasedMetadata).toHaveBeenCalledWith(item);
+  });
+
+  it('should use ISBN path for books', async () => {
+    const fetchISBNBasedMetadata = vi.fn().mockResolvedValue({ success: true });
+    fetchItemMetadata = createZotadataMethod('fetchItemMetadata', {
+      fetchISBNBasedMetadata,
+    });
+
+    const item = createMockItem({ id: 1, itemTypeID: 2 }); // book
+    await fetchItemMetadata(item);
+
+    expect(fetchISBNBasedMetadata).toHaveBeenCalledWith(item);
+  });
+
+  it('should skip unsupported item types', async () => {
+    const fetchDOIBasedMetadata = vi.fn();
+    const fetchISBNBasedMetadata = vi.fn();
+
+    fetchItemMetadata = createZotadataMethod('fetchItemMetadata', {
+      fetchDOIBasedMetadata,
+      fetchISBNBasedMetadata,
+    });
+
+    const item = createMockItem({ id: 1, itemTypeID: 99 }); // unsupported
+    const result = await fetchItemMetadata(item);
+
+    expect(result).toBe(false);
+    expect(fetchDOIBasedMetadata).not.toHaveBeenCalled();
+    expect(fetchISBNBasedMetadata).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test tests/unit/zotadata/integration.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/zotadata/integration.test.ts
+git commit -m "test: add Tier 3 integration tests"
+```
+
+---
+
+## Task 13: Run Full Test Suite and Coverage
+
+**Files:**
+- None (verification step)
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npm test`
+Expected: All tests pass
+
+- [ ] **Step 2: Run coverage report**
+
+Run: `npm run test:coverage`
+Expected: Coverage report shows 80%+ on Tier 1-2 functions
+
+- [ ] **Step 3: Fix any failing tests**
+
+If any tests fail, debug and fix them.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add .
+git commit -m "test: complete zotadata test coverage implementation
+
+- Tier 1: Utils, extractors, ISBN conversion tests
+- Tier 2: API clients, discovery, metadata, arXiv processing tests
+- Tier 3: Batch processing, integration tests
+- Mock infrastructure with fixtures for external APIs"
+```
+
+---
+
+## Summary
+
+| Tier | Test File | Functions | Est. Tests |
+|------|-----------|-----------|------------|
+| 1 | utils.test.ts | 4 | ~35 |
+| 1 | extractors.test.ts | 4 | ~40 |
+| 1 | isbn-convert.test.ts | 3 | ~20 |
+| 2 | api-clients.test.ts | 7 | ~50 |
+| 2 | discovery.test.ts | 2 | ~20 |
+| 2 | metadata.test.ts | 7 | ~40 |
+| 2 | arxiv-processing.test.ts | 5 | ~35 |
+| 2-3 | file-operations.test.ts | 7 | ~45 |
+| 3 | batch-processing.test.ts | 2 | ~20 |
+| 3 | integration.test.ts | 5 | ~20 |
+| **Total** | | **46** | **~325** |

--- a/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
@@ -26,6 +26,8 @@ tests/
 │   ├── zotero.ts              # Core Zotero mock (extend setup.ts)
 │   ├── zotero-items.ts        # Item mock factory
 │   ├── zotero-http.ts         # HTTP request mock with fixtures
+│   ├── zotero-translate.ts    # Zotero.Translate.Search mock
+│   ├── zotero-prefs.ts        # Zotero.Prefs mock
 │   └── fixtures/
 │       ├── crossref.ts        # CrossRef API response fixtures
 │       ├── openalex.ts        # OpenAlex API response fixtures
@@ -37,8 +39,10 @@ tests/
 │       ├── extractors.test.ts     # Tier 1: DOI, ISBN, arXiv extraction
 │       ├── isbn-convert.test.ts   # Tier 1: ISBN-10/13 conversion
 │       ├── api-clients.test.ts    # Tier 2: HTTP clients with mocks
+│       ├── discovery.test.ts      # Tier 2: DOI/ISBN discovery orchestration
 │       ├── metadata.test.ts       # Tier 2: metadata fetching
 │       ├── arxiv-processing.test.ts # Tier 2: arXiv pipeline
+│       ├── file-operations.test.ts # Tier 2-3: file finding and download
 │       ├── batch-processing.test.ts # Tier 3: batch operations
 │       └── integration.test.ts    # Tier 3: end-to-end with full mocks
 ```
@@ -49,6 +53,9 @@ tests/
 - Create HTTP mock layer with fixture support for API responses
 - Use `vi.fn()` for Zotero.HTTP.request mocking
 - Create item factory for consistent test data
+- Mock `Zotero.Translate.Search` for translator-based metadata fetching
+- Mock `Zotero.Prefs` for email configuration tests
+- Mock `Zotero.Item` with full method set (getField, setField, saveTx, etc.)
 
 ## Tier 1: Critical Tests
 
@@ -64,7 +71,7 @@ tests/
 
 | Function | Test Cases |
 |----------|------------|
-| `titleSimilarity` | Exact match, case insensitivity, stop word removal, punctuation handling, partial overlap, empty/null inputs |
+| `titleSimilarity` | Exact match, case insensitivity, stop word removal, punctuation handling, partial overlap, empty/null inputs, unicode/international chars, mathematical symbols (LaTeX-style), very long titles |
 | `sanitizeFileName` | Special chars (/\:*?"<>|), length limits, unicode, empty input |
 | `cleanDownloadUrl` | URL encoding, query params, fragments, invalid URLs |
 | `validatePDFData` | PDF header %PDF-, %%EOF trailer, minimum size, non-PDF data |
@@ -81,9 +88,9 @@ tests/
 
 | Function | Test Cases |
 |----------|------------|
-| `extractDOI` | DOI field, URL extraction (doi.org patterns), extra field, multiple DOI formats, invalid DOI |
+| `extractDOI` | DOI field, URL extraction (doi.org patterns), extra field, multiple DOI formats (10.xxxx/xxxx), invalid DOI |
 | `extractISBN` | ISBN field, ISBN-10/13, extra field, invalid ISBN |
-| `extractArxivId` | URL patterns (arxiv.org/abs/), extra field patterns, old-style IDs |
+| `extractArxivId` | URL patterns (arxiv.org/abs/), extra field patterns, old-style IDs (subject-class/xxxxx) |
 | `isArxivItem` | publicationTitle "arxiv", URL arxiv.org, extra field arXiv ID, title "arxiv", non-arXiv |
 
 ### isbn-convert.test.ts
@@ -91,6 +98,7 @@ tests/
 **Functions:**
 - `convertISBN10to13(isbn10)` - Convert ISBN-10 to ISBN-13
 - `convertISBN13to10(isbn13)` - Convert ISBN-13 to ISBN-10 (978 prefix only)
+- `formatISBNWithHyphens(isbn)` - Format ISBN with hyphens for display
 
 **Test Cases:**
 
@@ -98,6 +106,7 @@ tests/
 |----------|------------|
 | `convertISBN10to13` | Valid conversion, checksum calculation, invalid length |
 | `convertISBN13to10` | Valid 978 prefix conversion, non-978 rejection, checksum |
+| `formatISBNWithHyphens` | ISBN-10 formatting, ISBN-13 formatting, invalid input |
 
 ## Tier 2: High Priority Tests
 
@@ -107,8 +116,10 @@ tests/
 - `searchCrossRefForDOI(item)` - CrossRef DOI search
 - `searchOpenAlexExact(item, title)` - OpenAlex exact search
 - `searchOpenAlexTitleOnly(item, title)` - OpenAlex title search
-- `searchSemanticScholarForPublishedVersion(item)` - Semantic Scholar search
+- `searchSemanticScholarForDOI(item)` - Semantic Scholar DOI search
 - `fetchCrossRefMetadata(doi)` - Fetch metadata from CrossRef
+- `searchCrossRefByArxivId(arxivId)` - CrossRef search by arXiv ID
+- `searchCrossRefForPublishedVersion(item)` - CrossRef published version search
 
 **Test Cases:**
 
@@ -117,8 +128,23 @@ tests/
 | `searchCrossRefForDOI` | Match with title similarity, multiple results, no results, HTTP error, rate limit |
 | `searchOpenAlexExact` | DOI extraction, similarity threshold 0.95, no results |
 | `searchOpenAlexTitleOnly` | Similarity threshold 0.90, cleaned title matching |
-| `searchSemanticScholar` | DOI response, VENUE:TITLE format, arXiv filtering |
+| `searchSemanticScholarForDOI` | DOI response, VENUE:TITLE format, arXiv filtering |
 | `fetchCrossRefMetadata` | Metadata parsing, error handling |
+| `searchCrossRefByArxivId` | arXiv ID query, journal-article type, proceedings-article type |
+| `searchCrossRefForPublishedVersion` | Exclude arXiv container, title similarity 0.9 |
+
+### discovery.test.ts
+
+**Functions:**
+- `discoverDOI(item)` - Orchestrate DOI discovery across multiple APIs
+- `discoverISBN(item)` - Orchestrate ISBN discovery across multiple APIs
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `discoverDOI` | CrossRef found first, fallback to OpenAlex, fallback to Semantic Scholar, fallback to DBLP, fallback to Google Scholar, all fail → null |
+| `discoverISBN` | OpenLibrary found first, fallback to Google Books, all fail → null |
 
 ### metadata.test.ts
 
@@ -127,15 +153,19 @@ tests/
 - `fetchISBNBasedMetadata(item)` - ISBN-based metadata pipeline
 - `updateItemWithMetadata(item, metadata)` - Apply CrossRef metadata
 - `updateItemWithBookMetadata(item, metadata)` - Apply book metadata
+- `fetchBookMetadataViaTranslator(isbn, item)` - Zotero translator for books
+- `fetchDOIMetadataViaTranslator(doi, item)` - Zotero translator for DOI
 
 **Test Cases:**
 
 | Function | Test Cases |
 |----------|------------|
-| `fetchDOIBasedMetadata` | Existing DOI fetch, DOI discovery, translator fallback, error tagging |
-| `fetchISBNBasedMetadata` | Existing ISBN fetch, ISBN discovery, alternative format fallback |
+| `fetchDOIBasedMetadata` | Existing DOI fetch, DOI discovery, translator fallback, CrossRef API fallback, error tagging |
+| `fetchISBNBasedMetadata` | Existing ISBN fetch, ISBN discovery, translator success, alternative format fallback |
 | `updateItemWithMetadata` | Title, authors, volume/issue/pages, URL |
 | `updateItemWithBookMetadata` | Title, authors, publisher, date, pages |
+| `fetchBookMetadataViaTranslator` | Translator found, no translator, apply fields |
+| `fetchDOIMetadataViaTranslator` | Translator found, no translator, apply fields |
 
 ### arxiv-processing.test.ts
 
@@ -143,6 +173,8 @@ tests/
 - `processArxivItem(item)` - Process single arXiv item
 - `findPublishedVersion(item)` - Find published version of preprint
 - `convertToPreprint(item)` - Convert journalArticle to preprint
+- `updateItemAsPublishedVersion(item, publishedInfo)` - Update item with published info
+- `searchSemanticScholarForPublishedVersion(item)` - Semantic Scholar published search
 
 **Test Cases:**
 
@@ -151,6 +183,29 @@ tests/
 | `processArxivItem` | arXiv item with published version, no published version → preprint, non-arXiv skip, error tagging |
 | `findPublishedVersion` | arXiv ID search, CrossRef title fallback, Semantic Scholar fallback, null return |
 | `convertToPreprint` | Type change, repository field, publicationTitle clear, tag added |
+| `updateItemAsPublishedVersion` | VENUE format → conferencePaper, DOI format → journalArticle, metadata fetch |
+| `searchSemanticScholarForPublishedVersion` | Exclude arXiv venue, similarity threshold, DOI extraction |
+
+### file-operations.test.ts
+
+**Functions:**
+- `findFileForItem(item)` - Find PDF from multiple sources
+- `itemHasPDF(item)` - Check if item has valid PDF attachment
+- `verifyStoredAttachment(attachment)` - Verify attachment is stored file
+- `findUnpaywallPDF(doi)` - Find PDF via Unpaywall
+- `findArxivPDF(item)` - Find arXiv PDF for item
+- `findPublishedPDF(doi)` - Find published PDF from multiple sources
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `findFileForItem` | ISBN → InternetArchive/OpenLibrary/LibGen, DOI → Unpaywall/CORE/LibGen, arXiv → direct PDF |
+| `itemHasPDF` | Has PDF attachment, has non-PDF, has broken PDF, no attachments |
+| `verifyStoredAttachment` | Stored file, linked file, URL link, invalid attachment |
+| `findUnpaywallPDF` | Open access PDF found, no OA, email required, HTTP error |
+| `findArxivPDF` | arXiv ID found, search by title, no match |
+| `findPublishedPDF` | Unpaywall found, CORE fallback, none found |
 
 ## Tier 3: Medium Priority Tests
 
@@ -173,6 +228,8 @@ tests/
 - `fetchMetadataForSelectedItems()` - Full metadata pipeline
 - `processArxivItems()` - Full arXiv processing pipeline
 - `findSelectedFiles()` - Full file retrieval pipeline
+- `checkSelectedItems()` - Full attachment validation pipeline
+- `fetchItemMetadata(item)` - Single item metadata fetch
 
 **Test Cases:**
 
@@ -181,6 +238,8 @@ tests/
 | `fetchMetadataForSelectedItems` | Batch processing, supported item filtering, summary output |
 | `processArxivItems` | Candidate filtering, batch processing, statistics aggregation |
 | `findSelectedFiles` | Items needing files, source selection, download attempts |
+| `checkSelectedItems` | Batch validation, statistics aggregation |
+| `fetchItemMetadata` | Journal article path, book path, unsupported type |
 
 ## Tier 4: Lower Priority Tests
 
@@ -189,19 +248,63 @@ Minimal tests for UI code with DOM mocking:
 - `addToWindow()` - Element creation, event handler binding
 - `showDialog()` - Zotero.Notifier and window mocking
 
+## Intentionally Excluded Functions
+
+The following functions are excluded from test coverage with rationale:
+
+| Function | Reason |
+|----------|--------|
+| `init()` | Trivial initialization, no logic to test |
+| `addToAllWindows()` | Thin wrapper around addToWindow |
+| `removeFromWindow()` | DOM cleanup, tested indirectly |
+| `removeFromAllWindows()` | Thin wrapper |
+| `storeAddedElement()` | Trivial array push |
+| `log()` | Debug output, no business logic |
+| `showZoteroPopup()` | UI-only, requires extensive DOM mocking |
+| `showBatchSummary()` | String formatting + showDialog |
+| `showGenericBatchSummary()` | String formatting + showDialog |
+| `createProgressWindow()` | UI-only, requires Zotero window mocking |
+| `updateProgressWindow()` | UI-only |
+| `closeProgressWindow()` | UI-only |
+| `configureEmail()` | UI prompt + Prefs, minimal logic |
+| `getConfiguredEmail()` | Prefs read + UI prompt |
+| `createPublishedVersion()` | Creates new item - integration test only |
+| `updateAttachmentsForPublishedVersion()` | Attachment manipulation - hard to mock |
+| `moveAttachmentsWithPreprintSuffix()` | Attachment manipulation |
+| `downloadPublishedVersion()` | File download + attachment - integration level |
+| `downloadAndAttachFile()` | File download + attachment creation |
+| `manualDownloadAndImport()` | File download + filesystem |
+| `createAttachmentFromData()` | Filesystem + attachment creation |
+| `createAttachmentFromDataLegacy()` | Legacy filesystem operations |
+| `validateWrittenPDFFile()` | Filesystem operations |
+| `debugDownloadedContent()` | Debug helper, no business logic |
+| `searchGoogleScholarForDOI()` | Scraping, unreliable, anti-bot measures |
+| `tryCustomResolvers()` | External resolver configuration |
+| `tryCustomResolver()` | External resolver |
+| `getCustomResolvers()` | Configuration retrieval |
+| `getNestedProperty()` | Utility, trivial |
+| `cleanScihubUrl()` | URL cleaning for specific service |
+| `searchLibGen*` functions | External service, unreliable |
+| `findInternetArchiveBook()` | External service |
+| `checkInternetArchivePDF()` | External service |
+| `findOpenLibraryPDF()` | External service |
+| `findGoogleBooksFullText()` | External service |
+
 ## Estimated Coverage
 
 | Test File | Tier | Functions | Est. Test Cases |
 |-----------|------|-----------|-----------------|
-| `utils.test.ts` | 1 | 4 | ~30 |
-| `extractors.test.ts` | 1 | 4 | ~35 |
-| `isbn-convert.test.ts` | 1 | 2 | ~15 |
-| `api-clients.test.ts` | 2 | 5 | ~40 |
-| `metadata.test.ts` | 2 | 4 | ~25 |
-| `arxiv-processing.test.ts` | 2 | 3 | ~25 |
+| `utils.test.ts` | 1 | 4 | ~35 |
+| `extractors.test.ts` | 1 | 4 | ~40 |
+| `isbn-convert.test.ts` | 1 | 3 | ~20 |
+| `api-clients.test.ts` | 2 | 7 | ~50 |
+| `discovery.test.ts` | 2 | 2 | ~20 |
+| `metadata.test.ts` | 2 | 6 | ~35 |
+| `arxiv-processing.test.ts` | 2 | 5 | ~35 |
+| `file-operations.test.ts` | 2-3 | 6 | ~40 |
 | `batch-processing.test.ts` | 3 | 2 | ~20 |
-| `integration.test.ts` | 3 | 3 | ~10 |
-| **Total** | | **27** | **~200** |
+| `integration.test.ts` | 3 | 5 | ~20 |
+| **Total** | | **44** | **~315** |
 
 ## Implementation Notes
 
@@ -210,3 +313,5 @@ Minimal tests for UI code with DOM mocking:
 3. **Item factory**: Create helper function to generate mock items with common configurations
 4. **Isolation**: Each test file imports only the functions it tests (future extraction step)
 5. **Coverage target**: Aim for 80%+ on Tier 1-2 functions, 50%+ on Tier 3, minimal on Tier 4
+6. **Mock translators**: `Zotero.Translate.Search` needs custom mock for `fetchBookMetadataViaTranslator` and `fetchDOIMetadataViaTranslator` tests
+7. **File mocking**: For file operations, mock `Zotero.Attachments.importFromURL`, `Zotero.Attachments.importFromFile`

--- a/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
@@ -155,6 +155,7 @@ tests/
 - `updateItemWithBookMetadata(item, metadata)` - Apply book metadata
 - `fetchBookMetadataViaTranslator(isbn, item)` - Zotero translator for books
 - `fetchDOIMetadataViaTranslator(doi, item)` - Zotero translator for DOI
+- `tryAlternativeISBNFormats(originalISBN, item)` - Fallback ISBN format attempts
 
 **Test Cases:**
 
@@ -166,6 +167,7 @@ tests/
 | `updateItemWithBookMetadata` | Title, authors, publisher, date, pages |
 | `fetchBookMetadataViaTranslator` | Translator found, no translator, apply fields |
 | `fetchDOIMetadataViaTranslator` | Translator found, no translator, apply fields |
+| `tryAlternativeISBNFormats` | ISBN-10 to ISBN-13 conversion, ISBN-13 to ISBN-10 conversion, all formats fail |
 
 ### arxiv-processing.test.ts
 
@@ -193,6 +195,7 @@ tests/
 - `itemHasPDF(item)` - Check if item has valid PDF attachment
 - `verifyStoredAttachment(attachment)` - Verify attachment is stored file
 - `findUnpaywallPDF(doi)` - Find PDF via Unpaywall
+- `findCorePDFByDOI(doi)` - Find PDF via CORE API
 - `findArxivPDF(item)` - Find arXiv PDF for item
 - `findPublishedPDF(doi)` - Find published PDF from multiple sources
 
@@ -204,6 +207,7 @@ tests/
 | `itemHasPDF` | Has PDF attachment, has non-PDF, has broken PDF, no attachments |
 | `verifyStoredAttachment` | Stored file, linked file, URL link, invalid attachment |
 | `findUnpaywallPDF` | Open access PDF found, no OA, email required, HTTP error |
+| `findCorePDFByDOI` | PDF found with downloadUrl, no results, HTTP error |
 | `findArxivPDF` | arXiv ID found, search by title, no match |
 | `findPublishedPDF` | Unpaywall found, CORE fallback, none found |
 
@@ -214,6 +218,8 @@ tests/
 **Functions:**
 - `processBatch(items, processFn, options)` - Generic batch processor
 - `simpleAttachmentCheckBatch(item)` - Batch attachment validation
+
+**Note:** `simpleAttachmentCheck(item)` is indirectly tested via `simpleAttachmentCheckBatch`.
 
 **Test Cases:**
 
@@ -252,6 +258,8 @@ Minimal tests for UI code with DOM mocking:
 
 The following functions are excluded from test coverage with rationale:
 
+### Trivial / Thin Wrappers
+
 | Function | Reason |
 |----------|--------|
 | `init()` | Trivial initialization, no logic to test |
@@ -260,6 +268,12 @@ The following functions are excluded from test coverage with rationale:
 | `removeFromAllWindows()` | Thin wrapper |
 | `storeAddedElement()` | Trivial array push |
 | `log()` | Debug output, no business logic |
+| `getNestedProperty()` | Utility, trivial |
+
+### UI / DOM-Dependent
+
+| Function | Reason |
+|----------|--------|
 | `showZoteroPopup()` | UI-only, requires extensive DOM mocking |
 | `showBatchSummary()` | String formatting + showDialog |
 | `showGenericBatchSummary()` | String formatting + showDialog |
@@ -268,27 +282,52 @@ The following functions are excluded from test coverage with rationale:
 | `closeProgressWindow()` | UI-only |
 | `configureEmail()` | UI prompt + Prefs, minimal logic |
 | `getConfiguredEmail()` | Prefs read + UI prompt |
+
+### Filesystem / Attachment Operations
+
+| Function | Reason |
+|----------|--------|
 | `createPublishedVersion()` | Creates new item - integration test only |
 | `updateAttachmentsForPublishedVersion()` | Attachment manipulation - hard to mock |
 | `moveAttachmentsWithPreprintSuffix()` | Attachment manipulation |
 | `downloadPublishedVersion()` | File download + attachment - integration level |
 | `downloadAndAttachFile()` | File download + attachment creation |
+| `downloadFileForItem()` | Thin wrapper around downloadAndAttachFile |
 | `manualDownloadAndImport()` | File download + filesystem |
 | `createAttachmentFromData()` | Filesystem + attachment creation |
 | `createAttachmentFromDataLegacy()` | Legacy filesystem operations |
 | `validateWrittenPDFFile()` | Filesystem operations |
 | `debugDownloadedContent()` | Debug helper, no business logic |
+
+### External Services (Unreliable for Testing)
+
+| Function | Reason |
+|----------|--------|
 | `searchGoogleScholarForDOI()` | Scraping, unreliable, anti-bot measures |
+| `searchDBLPForDOI()` | External API, covered indirectly via discoverDOI tests |
+| `searchOpenLibraryForISBN()` | External API, covered indirectly via discoverISBN tests |
+| `searchGoogleBooksForISBN()` | External API, covered indirectly via discoverISBN tests |
+| `searchOpenAlexForDOI()` | Covered indirectly via discoverDOI tests |
 | `tryCustomResolvers()` | External resolver configuration |
 | `tryCustomResolver()` | External resolver |
 | `getCustomResolvers()` | Configuration retrieval |
-| `getNestedProperty()` | Utility, trivial |
 | `cleanScihubUrl()` | URL cleaning for specific service |
 | `searchLibGen*` functions | External service, unreliable |
 | `findInternetArchiveBook()` | External service |
 | `checkInternetArchivePDF()` | External service |
 | `findOpenLibraryPDF()` | External service |
 | `findGoogleBooksFullText()` | External service |
+
+### Internal Helper Functions
+
+| Function | Reason |
+|----------|--------|
+| `searchSemanticScholarExact()` | Internal helper for S2 search |
+| `searchSemanticScholarRelaxed()` | Internal helper for S2 search |
+| `searchSemanticScholarExactPublished()` | Internal helper for published search |
+| `searchSemanticScholarRelaxedPublished()` | Internal helper for published search |
+| `searchArxiv(title)` | Internal helper for findArxivPDF |
+| `simpleAttachmentCheck(item)` | Indirectly tested via simpleAttachmentCheckBatch |
 
 ## Estimated Coverage
 
@@ -299,12 +338,12 @@ The following functions are excluded from test coverage with rationale:
 | `isbn-convert.test.ts` | 1 | 3 | ~20 |
 | `api-clients.test.ts` | 2 | 7 | ~50 |
 | `discovery.test.ts` | 2 | 2 | ~20 |
-| `metadata.test.ts` | 2 | 6 | ~35 |
+| `metadata.test.ts` | 2 | 7 | ~40 |
 | `arxiv-processing.test.ts` | 2 | 5 | ~35 |
-| `file-operations.test.ts` | 2-3 | 6 | ~40 |
+| `file-operations.test.ts` | 2-3 | 7 | ~45 |
 | `batch-processing.test.ts` | 3 | 2 | ~20 |
 | `integration.test.ts` | 3 | 5 | ~20 |
-| **Total** | | **44** | **~315** |
+| **Total** | | **46** | **~325** |
 
 ## Implementation Notes
 
@@ -315,3 +354,4 @@ The following functions are excluded from test coverage with rationale:
 5. **Coverage target**: Aim for 80%+ on Tier 1-2 functions, 50%+ on Tier 3, minimal on Tier 4
 6. **Mock translators**: `Zotero.Translate.Search` needs custom mock for `fetchBookMetadataViaTranslator` and `fetchDOIMetadataViaTranslator` tests
 7. **File mocking**: For file operations, mock `Zotero.Attachments.importFromURL`, `Zotero.Attachments.importFromFile`
+8. **Utilities mock**: Mock `Zotero.Utilities.cleanDOI` to return input unchanged (or apply minimal cleaning) for DOI tests

--- a/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-22-zotadata-test-coverage-design.md
@@ -1,0 +1,212 @@
+# Test Coverage Design for zotadata.js
+
+**Date:** 2026-03-22
+**Context:** Major refactoring and TypeScript migration - need comprehensive test coverage as safety net
+
+## Overview
+
+This design provides stratified test coverage for `addon/chrome/content/scripts/zotadata.js` (4,348 lines, ~80 functions). Tests are prioritized by refactoring risk to maximize safety during TypeScript migration.
+
+## Approach: Stratified Coverage by Risk
+
+Tests are organized into four tiers based on refactoring risk:
+
+1. **Critical (Tier 1)**: Pure functions with edge cases - comprehensive tests
+2. **High Priority (Tier 2)**: API clients and processors - mock-based tests
+3. **Medium Priority (Tier 3)**: Batch processing and file operations - functional tests
+4. **Lower Priority (Tier 4)**: UI/menu code - minimal mock tests
+
+## Test Infrastructure
+
+### Directory Structure
+
+```
+tests/
+├── __mocks__/
+│   ├── zotero.ts              # Core Zotero mock (extend setup.ts)
+│   ├── zotero-items.ts        # Item mock factory
+│   ├── zotero-http.ts         # HTTP request mock with fixtures
+│   └── fixtures/
+│       ├── crossref.ts        # CrossRef API response fixtures
+│       ├── openalex.ts        # OpenAlex API response fixtures
+│       ├── semanticscholar.ts # Semantic Scholar response fixtures
+│       └── arxiv.ts           # arXiv API response fixtures
+├── unit/
+│   └── zotadata/
+│       ├── utils.test.ts          # Tier 1: titleSimilarity, sanitize, validate
+│       ├── extractors.test.ts     # Tier 1: DOI, ISBN, arXiv extraction
+│       ├── isbn-convert.test.ts   # Tier 1: ISBN-10/13 conversion
+│       ├── api-clients.test.ts    # Tier 2: HTTP clients with mocks
+│       ├── metadata.test.ts       # Tier 2: metadata fetching
+│       ├── arxiv-processing.test.ts # Tier 2: arXiv pipeline
+│       ├── batch-processing.test.ts # Tier 3: batch operations
+│       └── integration.test.ts    # Tier 3: end-to-end with full mocks
+```
+
+### Mock Strategy
+
+- Extend existing `src/__tests__/setup.ts` for Zotero globals
+- Create HTTP mock layer with fixture support for API responses
+- Use `vi.fn()` for Zotero.HTTP.request mocking
+- Create item factory for consistent test data
+
+## Tier 1: Critical Tests
+
+### utils.test.ts
+
+**Functions:**
+- `titleSimilarity(title1, title2)` - Jaccard similarity with normalization
+- `sanitizeFileName(filename)` - Clean special characters, length limits
+- `cleanDownloadUrl(url)` - URL normalization
+- `validatePDFData(data)` - PDF magic bytes validation
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `titleSimilarity` | Exact match, case insensitivity, stop word removal, punctuation handling, partial overlap, empty/null inputs |
+| `sanitizeFileName` | Special chars (/\:*?"<>|), length limits, unicode, empty input |
+| `cleanDownloadUrl` | URL encoding, query params, fragments, invalid URLs |
+| `validatePDFData` | PDF header %PDF-, %%EOF trailer, minimum size, non-PDF data |
+
+### extractors.test.ts
+
+**Functions:**
+- `extractDOI(item)` - Extract DOI from fields
+- `extractISBN(item)` - Extract ISBN from fields
+- `extractArxivId(item)` - Extract arXiv ID from item
+- `isArxivItem(item)` - Detect if item is from arXiv
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `extractDOI` | DOI field, URL extraction (doi.org patterns), extra field, multiple DOI formats, invalid DOI |
+| `extractISBN` | ISBN field, ISBN-10/13, extra field, invalid ISBN |
+| `extractArxivId` | URL patterns (arxiv.org/abs/), extra field patterns, old-style IDs |
+| `isArxivItem` | publicationTitle "arxiv", URL arxiv.org, extra field arXiv ID, title "arxiv", non-arXiv |
+
+### isbn-convert.test.ts
+
+**Functions:**
+- `convertISBN10to13(isbn10)` - Convert ISBN-10 to ISBN-13
+- `convertISBN13to10(isbn13)` - Convert ISBN-13 to ISBN-10 (978 prefix only)
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `convertISBN10to13` | Valid conversion, checksum calculation, invalid length |
+| `convertISBN13to10` | Valid 978 prefix conversion, non-978 rejection, checksum |
+
+## Tier 2: High Priority Tests
+
+### api-clients.test.ts
+
+**Functions:**
+- `searchCrossRefForDOI(item)` - CrossRef DOI search
+- `searchOpenAlexExact(item, title)` - OpenAlex exact search
+- `searchOpenAlexTitleOnly(item, title)` - OpenAlex title search
+- `searchSemanticScholarForPublishedVersion(item)` - Semantic Scholar search
+- `fetchCrossRefMetadata(doi)` - Fetch metadata from CrossRef
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `searchCrossRefForDOI` | Match with title similarity, multiple results, no results, HTTP error, rate limit |
+| `searchOpenAlexExact` | DOI extraction, similarity threshold 0.95, no results |
+| `searchOpenAlexTitleOnly` | Similarity threshold 0.90, cleaned title matching |
+| `searchSemanticScholar` | DOI response, VENUE:TITLE format, arXiv filtering |
+| `fetchCrossRefMetadata` | Metadata parsing, error handling |
+
+### metadata.test.ts
+
+**Functions:**
+- `fetchDOIBasedMetadata(item)` - DOI-based metadata pipeline
+- `fetchISBNBasedMetadata(item)` - ISBN-based metadata pipeline
+- `updateItemWithMetadata(item, metadata)` - Apply CrossRef metadata
+- `updateItemWithBookMetadata(item, metadata)` - Apply book metadata
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `fetchDOIBasedMetadata` | Existing DOI fetch, DOI discovery, translator fallback, error tagging |
+| `fetchISBNBasedMetadata` | Existing ISBN fetch, ISBN discovery, alternative format fallback |
+| `updateItemWithMetadata` | Title, authors, volume/issue/pages, URL |
+| `updateItemWithBookMetadata` | Title, authors, publisher, date, pages |
+
+### arxiv-processing.test.ts
+
+**Functions:**
+- `processArxivItem(item)` - Process single arXiv item
+- `findPublishedVersion(item)` - Find published version of preprint
+- `convertToPreprint(item)` - Convert journalArticle to preprint
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `processArxivItem` | arXiv item with published version, no published version → preprint, non-arXiv skip, error tagging |
+| `findPublishedVersion` | arXiv ID search, CrossRef title fallback, Semantic Scholar fallback, null return |
+| `convertToPreprint` | Type change, repository field, publicationTitle clear, tag added |
+
+## Tier 3: Medium Priority Tests
+
+### batch-processing.test.ts
+
+**Functions:**
+- `processBatch(items, processFn, options)` - Generic batch processor
+- `simpleAttachmentCheckBatch(item)` - Batch attachment validation
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `processBatch` | Batch size, concurrent processing, inter-batch delay, progress callback, error collection, return structure |
+| `simpleAttachmentCheckBatch` | No attachments, valid files, broken files removed, weblinks kept, error handling |
+
+### integration.test.ts
+
+**Functions:**
+- `fetchMetadataForSelectedItems()` - Full metadata pipeline
+- `processArxivItems()` - Full arXiv processing pipeline
+- `findSelectedFiles()` - Full file retrieval pipeline
+
+**Test Cases:**
+
+| Function | Test Cases |
+|----------|------------|
+| `fetchMetadataForSelectedItems` | Batch processing, supported item filtering, summary output |
+| `processArxivItems` | Candidate filtering, batch processing, statistics aggregation |
+| `findSelectedFiles` | Items needing files, source selection, download attempts |
+
+## Tier 4: Lower Priority Tests
+
+Minimal tests for UI code with DOM mocking:
+
+- `addToWindow()` - Element creation, event handler binding
+- `showDialog()` - Zotero.Notifier and window mocking
+
+## Estimated Coverage
+
+| Test File | Tier | Functions | Est. Test Cases |
+|-----------|------|-----------|-----------------|
+| `utils.test.ts` | 1 | 4 | ~30 |
+| `extractors.test.ts` | 1 | 4 | ~35 |
+| `isbn-convert.test.ts` | 1 | 2 | ~15 |
+| `api-clients.test.ts` | 2 | 5 | ~40 |
+| `metadata.test.ts` | 2 | 4 | ~25 |
+| `arxiv-processing.test.ts` | 2 | 3 | ~25 |
+| `batch-processing.test.ts` | 3 | 2 | ~20 |
+| `integration.test.ts` | 3 | 3 | ~10 |
+| **Total** | | **27** | **~200** |
+
+## Implementation Notes
+
+1. **Mock reuse**: Extend existing `src/__tests__/setup.ts` rather than creating parallel mock infrastructure
+2. **Fixture-driven**: API responses stored as fixtures for reproducible tests
+3. **Item factory**: Create helper function to generate mock items with common configurations
+4. **Isolation**: Each test file imports only the functions it tests (future extraction step)
+5. **Coverage target**: Aim for 80%+ on Tier 1-2 functions, 50%+ on Tier 3, minimal on Tier 4

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -71,3 +71,28 @@
 if (typeof document !== 'undefined') {
   (document as any).createXULElement = document.createElement.bind(document);
 }
+
+// Import mock utilities for tests
+import { createMockHTTP } from '../../tests/__mocks__/zotero-http';
+import { createMockPrefs, clearPrefs } from '../../tests/__mocks__/zotero-prefs';
+import { resetMockCounters } from '../../tests/__mocks__/zotero-items';
+
+// Extend Zotero mock with test utilities
+(globalThis as any).Zotero.Prefs = createMockPrefs();
+
+// Helper to reset HTTP mock with fixtures
+(globalThis as any).__resetHTTPMock = () => {
+  (globalThis as any).Zotero.HTTP = createMockHTTP();
+};
+
+// Helper to set custom HTTP mock
+(globalThis as any).__setHTTPMock = (mock: any) => {
+  (globalThis as any).Zotero.HTTP = mock;
+};
+
+// Reset mocks between tests
+beforeEach(() => {
+  (globalThis as any).__resetHTTPMock?.();
+  clearPrefs();
+  resetMockCounters();
+});

--- a/tests/__mocks__/fixtures/arxiv.ts
+++ b/tests/__mocks__/fixtures/arxiv.ts
@@ -1,0 +1,24 @@
+// tests/__mocks__/fixtures/arxiv.ts
+export const arxivFixtures = {
+  singleEntry: {
+    status: 200,
+    responseText: `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2301.12345</id>
+    <title>Test arXiv Paper</title>
+    <author><name>John Smith</name></author>
+    <summary>Abstract text</summary>
+    <link href="http://arxiv.org/pdf/2301.12345" rel="alternate" type="application/pdf"/>
+  </entry>
+</feed>`,
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>`,
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/fixtures/core.ts
+++ b/tests/__mocks__/fixtures/core.ts
@@ -1,0 +1,84 @@
+// tests/__mocks__/fixtures/core.ts
+export const coreFixtures = {
+  pdfFound: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [
+        {
+          id: '12345',
+          title: 'Test Paper',
+          downloadUrl: 'https://core.ac.uk/download/pdf/12345.pdf',
+          doi: '10.1000/test.doi',
+        },
+      ],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  multipleResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [
+        {
+          id: '11111',
+          title: 'First Paper',
+          downloadUrl: null,
+          doi: '10.1000/test1.doi',
+        },
+        {
+          id: '22222',
+          title: 'Second Paper',
+          downloadUrl: 'https://core.ac.uk/download/pdf/22222.pdf',
+          doi: '10.1000/test2.doi',
+        },
+      ],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noDownloadUrl: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [
+        {
+          id: '12345',
+          title: 'Test Paper',
+          downloadUrl: null,
+          doi: '10.1000/test.doi',
+        },
+      ],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  nonPdfUrl: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [
+        {
+          id: '12345',
+          title: 'Test Paper',
+          downloadUrl: 'https://example.com/page.html',
+          doi: '10.1000/test.doi',
+        },
+      ],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  serverError: {
+    status: 500,
+    responseText: JSON.stringify({
+      error: 'Internal server error',
+    }),
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/fixtures/crossref.ts
+++ b/tests/__mocks__/fixtures/crossref.ts
@@ -1,0 +1,101 @@
+// tests/__mocks__/fixtures/crossref.ts
+export const crossrefFixtures = {
+  singleWork: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [{
+          DOI: '10.1000/test.doi',
+          title: ['Test Paper Title'],
+          author: [{ given: 'John', family: 'Smith' }],
+          'published-print': { 'date-parts': [[2023]] },
+          type: 'journal-article',
+        }],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  multipleWorks: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [
+          {
+            DOI: '10.1000/test1.doi',
+            title: ['First Paper'],
+            author: [{ given: 'John', family: 'Smith' }],
+            type: 'journal-article',
+          },
+          {
+            DOI: '10.1000/test2.doi',
+            title: ['Second Paper'],
+            author: [{ given: 'Jane', family: 'Doe' }],
+            type: 'journal-article',
+          },
+        ],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: { items: [] },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  arxivMatch: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        items: [{
+          DOI: '10.1000/published.doi',
+          title: ['Published Version of arXiv Paper'],
+          type: 'journal-article',
+        }],
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  metadata: {
+    status: 200,
+    responseText: JSON.stringify({
+      message: {
+        DOI: '10.1000/test.doi',
+        title: ['Full Metadata Paper'],
+        author: [
+          { given: 'John', family: 'Smith' },
+          { given: 'Jane', family: 'Doe' },
+        ],
+        'container-title': ['Test Journal'],
+        'published-print': { 'date-parts': [[2023, 5, 15]] },
+        volume: '10',
+        issue: '2',
+        page: '123-145',
+        type: 'journal-article',
+        URL: 'https://doi.org/10.1000/test.doi',
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  rateLimited: {
+    status: 429,
+    responseText: JSON.stringify({
+      message: 'Rate limit exceeded',
+    }),
+    getResponseHeader: () => null,
+  },
+
+  serverError: {
+    status: 500,
+    responseText: JSON.stringify({
+      message: 'Internal server error',
+    }),
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/fixtures/openalex.ts
+++ b/tests/__mocks__/fixtures/openalex.ts
@@ -6,6 +6,7 @@ export const openalexFixtures = {
       results: [{
         id: 'https://openalex.org/W123456789',
         display_name: 'Test Paper Title',
+        title: 'Test Paper Title',
         authorships: [
           { author: { display_name: 'John Smith' } },
         ],
@@ -24,6 +25,7 @@ export const openalexFixtures = {
       results: [{
         id: 'https://openalex.org/W123456789',
         display_name: 'Open Access Paper',
+        title: 'Open Access Paper',
         doi: 'https://doi.org/10.1000/oa.doi',
         open_access: {
           is_oa: true,

--- a/tests/__mocks__/fixtures/openalex.ts
+++ b/tests/__mocks__/fixtures/openalex.ts
@@ -1,0 +1,46 @@
+// tests/__mocks__/fixtures/openalex.ts
+export const openalexFixtures = {
+  singleWork: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [{
+        id: 'https://openalex.org/W123456789',
+        display_name: 'Test Paper Title',
+        authorships: [
+          { author: { display_name: 'John Smith' } },
+        ],
+        publication_year: 2023,
+        doi: 'https://doi.org/10.1000/test.doi',
+        open_access: { is_oa: false },
+      }],
+      meta: { count: 1 },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  withPdf: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [{
+        id: 'https://openalex.org/W123456789',
+        display_name: 'Open Access Paper',
+        doi: 'https://doi.org/10.1000/oa.doi',
+        open_access: {
+          is_oa: true,
+          oa_url: 'https://example.com/paper.pdf',
+        },
+      }],
+      meta: { count: 1 },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({
+      results: [],
+      meta: { count: 0 },
+    }),
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/fixtures/semanticscholar.ts
+++ b/tests/__mocks__/fixtures/semanticscholar.ts
@@ -1,0 +1,51 @@
+// tests/__mocks__/fixtures/semanticscholar.ts
+export const semanticscholarFixtures = {
+  singlePaper: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'abc123',
+        title: 'Test Paper Title',
+        year: 2023,
+        venue: 'Test Conference',
+        externalIds: { DOI: '10.1000/test.doi' },
+        authors: [{ name: 'John Smith' }],
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  arxivPaper: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'arxiv123',
+        title: 'arXiv Paper',
+        venue: 'arXiv',
+        externalIds: { ArXiv: '2301.12345' },
+        authors: [{ name: 'Jane Doe' }],
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  publishedVersion: {
+    status: 200,
+    responseText: JSON.stringify({
+      data: [{
+        paperId: 'pub123',
+        title: 'Published Version',
+        venue: 'Nature',
+        year: 2024,
+        externalIds: { DOI: '10.1000/published.doi' },
+      }],
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noResults: {
+    status: 200,
+    responseText: JSON.stringify({ data: [] }),
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/fixtures/unpaywall.ts
+++ b/tests/__mocks__/fixtures/unpaywall.ts
@@ -1,0 +1,51 @@
+// tests/__mocks__/fixtures/unpaywall.ts
+export const unpaywallFixtures = {
+  openAccessPDF: {
+    status: 200,
+    responseText: JSON.stringify({
+      is_oa: true,
+      best_oa_location: {
+        url_for_pdf: 'https://example.com/paper.pdf',
+        host_type: 'publisher',
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noOpenAccess: {
+    status: 200,
+    responseText: JSON.stringify({
+      is_oa: false,
+      best_oa_location: null,
+    }),
+    getResponseHeader: () => null,
+  },
+
+  noPDFURL: {
+    status: 200,
+    responseText: JSON.stringify({
+      is_oa: true,
+      best_oa_location: {
+        url_for_pdf: null,
+        host_type: 'repository',
+      },
+    }),
+    getResponseHeader: () => null,
+  },
+
+  notFound: {
+    status: 404,
+    responseText: JSON.stringify({
+      error: 'Not found',
+    }),
+    getResponseHeader: () => null,
+  },
+
+  serverError: {
+    status: 500,
+    responseText: JSON.stringify({
+      error: 'Internal server error',
+    }),
+    getResponseHeader: () => null,
+  },
+};

--- a/tests/__mocks__/zotero-http.ts
+++ b/tests/__mocks__/zotero-http.ts
@@ -1,0 +1,48 @@
+// tests/__mocks__/zotero-http.ts
+import { vi } from 'vitest';
+
+export interface MockResponse {
+  status: number;
+  responseText: string;
+  response?: string;
+  getResponseHeader?: (name: string) => string | null;
+}
+
+export type FixtureLoader = (url: string) => MockResponse | null;
+
+const fixtures: Map<string, MockResponse> = new Map();
+const fixtureLoaders: FixtureLoader[] = [];
+
+export function registerFixture(urlPattern: string | RegExp, response: MockResponse) {
+  fixtures.set(urlPattern.toString(), response);
+}
+
+export function registerFixtureLoader(loader: FixtureLoader) {
+  fixtureLoaders.push(loader);
+}
+
+export function clearFixtures() {
+  fixtures.clear();
+}
+
+export function createMockHTTP() {
+  return {
+    request: vi.fn(async (method: string, url: string, _options?: any) => {
+      for (const [pattern, response] of fixtures) {
+        if (url.match(pattern.replace(/^\/|\/$/g, ''))) {
+          return response;
+        }
+      }
+      for (const loader of fixtureLoaders) {
+        const response = loader(url);
+        if (response) return response;
+      }
+      return {
+        status: 404,
+        responseText: '{}',
+        response: '{}',
+        getResponseHeader: () => null,
+      };
+    }),
+  };
+}

--- a/tests/__mocks__/zotero-items.test.ts
+++ b/tests/__mocks__/zotero-items.test.ts
@@ -1,0 +1,35 @@
+// tests/__mocks__/zotero-items.test.ts
+import { describe, it, expect } from 'vitest';
+import { createMockItem, createMockAttachment } from './zotero-items';
+
+describe('createMockItem', () => {
+  it('should create item with default fields', () => {
+    const item = createMockItem();
+    expect(item.getField('title')).toBe('Test Title');
+    expect(item.id).toBeDefined();
+  });
+
+  it('should create item with custom fields', () => {
+    const item = createMockItem({
+      title: 'Custom Title',
+      DOI: '10.1000/test.doi'
+    });
+    expect(item.getField('title')).toBe('Custom Title');
+    expect(item.getField('DOI')).toBe('10.1000/test.doi');
+  });
+
+  it('should support setField and getField', () => {
+    const item = createMockItem();
+    item.setField('title', 'New Title');
+    expect(item.getField('title')).toBe('New Title');
+  });
+});
+
+describe('createMockAttachment', () => {
+  it('should create attachment with link mode', () => {
+    const attachment = createMockAttachment({
+      linkMode: 2 // LINK_MODE_IMPORTED_FILE
+    });
+    expect(attachment.attachmentLinkMode).toBe(2);
+  });
+});

--- a/tests/__mocks__/zotero-items.ts
+++ b/tests/__mocks__/zotero-items.ts
@@ -1,0 +1,84 @@
+// tests/__mocks__/zotero-items.ts
+import { vi } from 'vitest';
+
+export interface MockItemConfig {
+  id?: number;
+  itemTypeID?: number;
+  title?: string;
+  DOI?: string;
+  ISBN?: string;
+  url?: string;
+  extra?: string;
+  publicationTitle?: string;
+  date?: string;
+  creators?: Array<{ firstName?: string; lastName?: string }>;
+}
+
+let itemCounter = 0;
+
+export function createMockItem(config: MockItemConfig = {}) {
+  const id = config.id ?? ++itemCounter;
+  const fields: Record<string, string> = {
+    title: config.title ?? 'Test Title',
+    DOI: config.DOI ?? '',
+    ISBN: config.ISBN ?? '',
+    url: config.url ?? '',
+    extra: config.extra ?? '',
+    publicationTitle: config.publicationTitle ?? '',
+    date: config.date ?? '',
+  };
+
+  const creators = config.creators ?? [];
+  const tags: Array<{ tag: string; type: number }> = [];
+
+  return {
+    id,
+    itemTypeID: config.itemTypeID ?? 1,
+    get id() { return id; },
+
+    getField: vi.fn((fieldName: string) => fields[fieldName] ?? ''),
+    setField: vi.fn((fieldName: string, value: string) => {
+      fields[fieldName] = value;
+    }),
+
+    getCreators: vi.fn(() => creators),
+    getAttachments: vi.fn(() => []),
+
+    hasTag: vi.fn((tagName: string) => tags.some(t => t.tag === tagName)),
+    addTag: vi.fn((tag: string, type: number = 0) => {
+      tags.push({ tag, type });
+    }),
+
+    saveTx: vi.fn(async () => id),
+    eraseTx: vi.fn(async () => {}),
+    setType: vi.fn(() => {}),
+  } as any;
+}
+
+export interface MockAttachmentConfig {
+  id?: number;
+  linkMode?: number;
+  filePath?: string | null;
+  fileExists?: boolean;
+}
+
+let attachmentCounter = 0;
+
+export function resetMockCounters() {
+  itemCounter = 0;
+  attachmentCounter = 0;
+}
+
+export function createMockAttachment(config: MockAttachmentConfig = {}) {
+  const id = config.id ?? ++attachmentCounter;
+  const filePath = config.filePath;
+  const fileExists = config.fileExists ?? (filePath !== null && filePath !== undefined);
+
+  return {
+    id,
+    attachmentLinkMode: config.linkMode ?? 2,
+    getFilePath: vi.fn(() => filePath ?? null),
+    getFile: vi.fn(() => fileExists ? { exists: () => true } : null),
+    eraseTx: vi.fn(async () => {}),
+  } as any;
+}

--- a/tests/__mocks__/zotero-items.ts
+++ b/tests/__mocks__/zotero-items.ts
@@ -42,6 +42,14 @@ export function createMockItem(config: MockItemConfig = {}) {
     }),
 
     getCreators: vi.fn(() => creators),
+    setCreators: vi.fn((newCreators: any[]) => {
+      creators.length = 0;
+      creators.push(...newCreators);
+    }),
+    setCreator: vi.fn((index: number, creator: any) => {
+      creators[index] = creator;
+    }),
+    numCreators: () => creators.length,
     getAttachments: vi.fn(() => []),
 
     hasTag: vi.fn((tagName: string) => tags.some(t => t.tag === tagName)),

--- a/tests/__mocks__/zotero-prefs.ts
+++ b/tests/__mocks__/zotero-prefs.ts
@@ -1,0 +1,26 @@
+// tests/__mocks__/zotero-prefs.ts
+import { vi } from 'vitest';
+
+const prefs: Map<string, any> = new Map();
+
+export function createMockPrefs() {
+  return {
+    get: vi.fn((key: string, defaultValue?: any) => {
+      return prefs.has(key) ? prefs.get(key) : defaultValue;
+    }),
+    set: vi.fn((key: string, value: any) => {
+      prefs.set(key, value);
+    }),
+    clear: vi.fn((key: string) => {
+      prefs.delete(key);
+    }),
+  };
+}
+
+export function setPref(key: string, value: any) {
+  prefs.set(key, value);
+}
+
+export function clearPrefs() {
+  prefs.clear();
+}

--- a/tests/__mocks__/zotero-translate.ts
+++ b/tests/__mocks__/zotero-translate.ts
@@ -1,0 +1,33 @@
+// tests/__mocks__/zotero-translate.ts
+import { vi } from 'vitest';
+
+export interface MockTranslatorConfig {
+  found?: boolean;
+  item?: {
+    title?: string;
+    creators?: Array<{ firstName: string; lastName: string }>;
+    [key: string]: any;
+  };
+}
+
+export function createMockTranslate(config: MockTranslatorConfig = {}) {
+  return vi.fn().mockImplementation(() => ({
+    setSearch: vi.fn(),
+    setHandler: vi.fn((_type: string, callback: (items: any[]) => void) => {
+      if (config.found && config.item) {
+        setTimeout(() => callback([config.item]), 0);
+      } else {
+        setTimeout(() => callback([]), 0);
+      }
+    }),
+    translate: vi.fn(),
+  }));
+}
+
+export function setupTranslateMock(config?: MockTranslatorConfig) {
+  const mock = createMockTranslate(config);
+  (globalThis as any).Zotero.Translate = {
+    Search: mock,
+  };
+  return mock;
+}

--- a/tests/helpers/extract-function.ts
+++ b/tests/helpers/extract-function.ts
@@ -11,10 +11,10 @@ let zotadataCode: string | null = null;
 /**
  * Extract the entire body of a method, handling nested braces correctly
  */
-function extractMethodBody(code: string, methodName: string): { params: string[]; body: string } | null {
-  // Match method definition pattern: methodName(...) {
+function extractMethodBody(code: string, methodName: string): { params: string[]; body: string; isAsync: boolean } | null {
+  // Match method definition pattern: [async] methodName(...) {
   const methodStartRegex = new RegExp(
-    `^(\\s*)${methodName}\\s*\\(([^)]*)\\)\\s*\\{`,
+    `^(\\s*)(?:async\\s+)?${methodName}\\s*\\(([^)]*)\\)\\s*\\{`,
     'm'
   );
 
@@ -24,6 +24,11 @@ function extractMethodBody(code: string, methodName: string): { params: string[]
   const indent = startMatch[1];
   const paramsStr = startMatch[2];
   const params = paramsStr.split(',').map(p => p.trim()).filter(p => p);
+
+  // Check if the method is async by looking at the actual code
+  const lineStart = startMatch.index!;
+  const beforeMethod = code.substring(lineStart, lineStart + startMatch[0].length);
+  const isAsync = beforeMethod.includes('async ');
 
   // Find the start position of the method body
   const startIndex = startMatch.index! + startMatch[0].length;
@@ -50,7 +55,7 @@ function extractMethodBody(code: string, methodName: string): { params: string[]
   if (braceCount !== 0) return null;
 
   const body = code.substring(startIndex, bodyEnd);
-  return { params, body };
+  return { params, body, isAsync };
 }
 
 /**
@@ -68,12 +73,19 @@ export function extractFunction(name: string): Function | null {
   const extracted = extractMethodBody(zotadataCode, name);
   if (!extracted) return null;
 
-  const { params, body } = extracted;
+  const { params, body, isAsync } = extracted;
 
   try {
     // Create a function from the extracted body
     // For methods that don't use `this`, we can create a standalone function
-    const fn = new Function(...params, body);
+    let fn: Function;
+    if (isAsync) {
+      // Create async function that preserves 'this' binding
+      // new Function returns a regular function, then we invoke it to get the async function
+      fn = new Function(`return async function(${params.join(',')}) { ${body} }`)();
+    } else {
+      fn = new Function(...params, body);
+    }
     zotadataCache.set(name, fn);
     return fn;
   } catch (error) {

--- a/tests/helpers/extract-function.ts
+++ b/tests/helpers/extract-function.ts
@@ -1,0 +1,123 @@
+// tests/helpers/extract-function.ts
+// Helper to extract and test functions from zotadata.js
+
+import fs from 'fs';
+import path from 'path';
+
+const zotadataPath = path.join(process.cwd(), 'addon/chrome/content/scripts/zotadata.js');
+const zotadataCache: Map<string, Function> = new Map();
+let zotadataCode: string | null = null;
+
+/**
+ * Extract the entire body of a method, handling nested braces correctly
+ */
+function extractMethodBody(code: string, methodName: string): { params: string[]; body: string } | null {
+  // Match method definition pattern: methodName(...) {
+  const methodStartRegex = new RegExp(
+    `^(\\s*)${methodName}\\s*\\(([^)]*)\\)\\s*\\{`,
+    'm'
+  );
+
+  const startMatch = code.match(methodStartRegex);
+  if (!startMatch) return null;
+
+  const indent = startMatch[1];
+  const paramsStr = startMatch[2];
+  const params = paramsStr.split(',').map(p => p.trim()).filter(p => p);
+
+  // Find the start position of the method body
+  const startIndex = startMatch.index! + startMatch[0].length;
+
+  // Find the matching closing brace
+  let braceCount = 1;
+  let pos = startIndex;
+  let bodyEnd = startIndex;
+
+  while (pos < code.length && braceCount > 0) {
+    const char = code[pos];
+    if (char === '{') {
+      braceCount++;
+    } else if (char === '}') {
+      braceCount--;
+      if (braceCount === 0) {
+        bodyEnd = pos;
+        break;
+      }
+    }
+    pos++;
+  }
+
+  if (braceCount !== 0) return null;
+
+  const body = code.substring(startIndex, bodyEnd);
+  return { params, body };
+}
+
+/**
+ * Extract a function from zotadata.js by name
+ */
+export function extractFunction(name: string): Function | null {
+  if (zotadataCache.has(name)) {
+    return zotadataCache.get(name)!;
+  }
+
+  if (!zotadataCode) {
+    zotadataCode = fs.readFileSync(zotadataPath, 'utf-8');
+  }
+
+  const extracted = extractMethodBody(zotadataCode, name);
+  if (!extracted) return null;
+
+  const { params, body } = extracted;
+
+  try {
+    // Create a function from the extracted body
+    // For methods that don't use `this`, we can create a standalone function
+    const fn = new Function(...params, body);
+    zotadataCache.set(name, fn);
+    return fn;
+  } catch (error) {
+    console.error(`Failed to create function ${name}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Create a bound method with context for functions that use `this`
+ */
+export function createZotadataMethod<T = Function>(name: string, context: Record<string, unknown> = {}): T {
+  const extracted = extractFunction(name);
+  if (!extracted) {
+    throw new Error(`Function ${name} not found in zotadata.js`);
+  }
+
+  const defaultContext = {
+    log: () => {},
+    debugDownloadedContent: () => {},
+    ...context,
+  };
+
+  return (extracted as Function).bind(defaultContext) as T;
+}
+
+/**
+ * Get the raw source code of a method (useful for inspection/debugging)
+ */
+export function getMethodSource(name: string): string | null {
+  if (!zotadataCode) {
+    zotadataCode = fs.readFileSync(zotadataPath, 'utf-8');
+  }
+
+  const extracted = extractMethodBody(zotadataCode, name);
+  if (!extracted) return null;
+
+  return extracted.body;
+}
+
+/**
+ * Clear the cache (useful for testing)
+ */
+export function clearCache(): void {
+  zotadataCache.clear();
+  zotadataCode = null;
+}

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -1,0 +1,108 @@
+// tests/helpers/test-utils.ts
+// Shared test utilities for zotadata tests
+
+import { vi } from 'vitest';
+import { createMockHTTP, clearFixtures } from '../__mocks__/zotero-http';
+
+/**
+ * Item type IDs used by Zotero
+ */
+export const ItemTypeID = {
+  JOURNAL_ARTICLE: 1,
+  BOOK: 2,
+  CONFERENCE_PAPER: 3,
+  PREPRINT: 4,
+} as const;
+
+/**
+ * Attachment link modes
+ */
+export const LinkMode = {
+  LINKED_URL: 1,
+  IMPORTED_FILE: 2,
+  LINKED_FILE: 3,
+} as const;
+
+export interface ZoteroMockConfig {
+  /** Include HTTP mock */
+  http?: boolean;
+  /** Include Utilities mock */
+  utilities?: boolean;
+  /** Include Date mock */
+  date?: boolean;
+  /** Include ItemTypes mock */
+  itemTypes?: boolean;
+  /** Custom HTTP mock */
+  httpMock?: ReturnType<typeof createMockHTTP>;
+}
+
+/**
+ * Set up Zotero global mock for tests
+ * Reduces duplication across test files
+ */
+export function setupZoteroMock(config: ZoteroMockConfig = {}) {
+  const {
+    http = true,
+    utilities = true,
+    date = true,
+    itemTypes = false,
+    httpMock,
+  } = config;
+
+  const mockHTTP = httpMock ?? (http ? createMockHTTP() : undefined);
+
+  const mockZotero: Record<string, unknown> = {};
+
+  if (mockHTTP) {
+    mockZotero.HTTP = mockHTTP;
+  }
+
+  if (utilities) {
+    mockZotero.Utilities = {
+      cleanDOI: (d: string) => (d ? d.trim().toLowerCase() : d),
+      cleanISBN: (i: string) => i,
+      cleanURL: (u: string) => u,
+    };
+  }
+
+  if (date) {
+    mockZotero.Date = {
+      strToDate: (d: string) => ({ year: d?.match(/\d{4}/)?.[0] }),
+    };
+  }
+
+  if (itemTypes) {
+    mockZotero.ItemTypes = {
+      getID: (type: string) => {
+        const types: Record<string, number> = {
+          journalArticle: ItemTypeID.JOURNAL_ARTICLE,
+          book: ItemTypeID.BOOK,
+          conferencePaper: ItemTypeID.CONFERENCE_PAPER,
+          preprint: ItemTypeID.PREPRINT,
+        };
+        return types[type] ?? null;
+      },
+      getName: (id: number) => {
+        const names: Record<number, string> = {
+          [ItemTypeID.JOURNAL_ARTICLE]: 'journalArticle',
+          [ItemTypeID.BOOK]: 'book',
+          [ItemTypeID.CONFERENCE_PAPER]: 'conferencePaper',
+          [ItemTypeID.PREPRINT]: 'preprint',
+        };
+        return names[id] ?? null;
+      },
+    };
+  }
+
+  (globalThis as any).Zotero = mockZotero;
+
+  return { mockHTTP };
+}
+
+/**
+ * Common beforeEach setup for zotadata tests
+ */
+export function zotadataTestSetup() {
+  clearFixtures();
+  return setupZoteroMock();
+}

--- a/tests/unit/zotadata/api-clients.test.ts
+++ b/tests/unit/zotadata/api-clients.test.ts
@@ -1,0 +1,206 @@
+// tests/unit/zotadata/api-clients.test.ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { createMockHTTP, registerFixture, clearFixtures } from '../../__mocks__/zotero-http';
+import { crossrefFixtures } from '../../__mocks__/fixtures/crossref';
+import { openalexFixtures } from '../../__mocks__/fixtures/openalex';
+
+describe('API Clients', () => {
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    clearCache();
+    clearFixtures();
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      HTTP_request: mockHTTP.request,
+      Utilities: {
+        cleanDOI: (d: string) => d ? d.trim().toLowerCase() : d,
+      },
+      Date: {
+        strToDate: (d: string) => ({ year: d?.match(/\d{4}/)?.[0] }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearFixtures();
+  });
+
+  describe('searchCrossRefForDOI', () => {
+    let searchCrossRefForDOI: any;
+
+    beforeEach(() => {
+      searchCrossRefForDOI = createZotadataMethod('searchCrossRefForDOI', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should find DOI with matching title', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.singleWork);
+      const item = createMockItem({
+        title: 'Test Paper Title',
+        creators: [{ lastName: 'Smith' }],
+        date: '2023',
+      });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should return null for no results', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.noResults);
+      const item = createMockItem({ title: 'Nonexistent Paper' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.serverError);
+      const item = createMockItem({ title: 'Test' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+
+    it('should handle rate limiting', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.rateLimited);
+      const item = createMockItem({ title: 'Test' });
+      const result = await searchCrossRefForDOI(item);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('fetchCrossRefMetadata', () => {
+    let fetchCrossRefMetadata: any;
+
+    beforeEach(() => {
+      fetchCrossRefMetadata = createZotadataMethod('fetchCrossRefMetadata');
+    });
+
+    it('should fetch and parse metadata', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.metadata);
+      const result = await fetchCrossRefMetadata('10.1000/test.doi');
+      expect(result).toMatchObject({
+        title: ['Full Metadata Paper'],
+        DOI: '10.1000/test.doi',
+        type: 'journal-article',
+      });
+    });
+  });
+
+  describe('searchCrossRefByArxivId', () => {
+    let searchCrossRefByArxivId: any;
+
+    beforeEach(() => {
+      searchCrossRefByArxivId = createZotadataMethod('searchCrossRefByArxivId');
+    });
+
+    it('should find published version by arXiv ID', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.arxivMatch);
+      const result = await searchCrossRefByArxivId('2301.12345');
+      expect(result).toBe('10.1000/published.doi');
+    });
+  });
+
+  describe('searchOpenAlexExact', () => {
+    let searchOpenAlexExact: any;
+
+    beforeEach(() => {
+      searchOpenAlexExact = createZotadataMethod('searchOpenAlexExact', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should find DOI with high similarity threshold', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.singleWork);
+      const item = createMockItem({
+        title: 'Test Paper Title',
+        DOI: '10.1000/test.doi',
+      });
+      const result = await searchOpenAlexExact(item, 'Test Paper Title');
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should return null for no results', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.noResults);
+      const item = createMockItem({ title: 'Nonexistent' });
+      const result = await searchOpenAlexExact(item, 'Nonexistent');
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('searchOpenAlexTitleOnly', () => {
+    let searchOpenAlexTitleOnly: any;
+
+    beforeEach(() => {
+      searchOpenAlexTitleOnly = createZotadataMethod('searchOpenAlexTitleOnly', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should search by title with 0.90 threshold', async () => {
+      registerFixture('api.openalex.org', openalexFixtures.singleWork);
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchOpenAlexTitleOnly(item, 'Test Paper Title');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('searchSemanticScholarForDOI', () => {
+    let searchSemanticScholarForDOI: any;
+
+    beforeEach(() => {
+      searchSemanticScholarForDOI = createZotadataMethod('searchSemanticScholarForDOI', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchSemanticScholarExact: createZotadataMethod('searchSemanticScholarExact', {
+          titleSimilarity: createZotadataMethod('titleSimilarity'),
+        }),
+        searchSemanticScholarRelaxed: createZotadataMethod('searchSemanticScholarRelaxed', {
+          titleSimilarity: createZotadataMethod('titleSimilarity'),
+        }),
+      });
+    });
+
+    it('should find DOI from Semantic Scholar', async () => {
+      const { semanticscholarFixtures } = await import('../../__mocks__/fixtures/semanticscholar');
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.singlePaper);
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchSemanticScholarForDOI(item);
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should filter arXiv venues', async () => {
+      const { semanticscholarFixtures } = await import('../../__mocks__/fixtures/semanticscholar');
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.arxivPaper);
+      const item = createMockItem({ title: 'arXiv Paper' });
+      const result = await searchSemanticScholarForDOI(item);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('searchCrossRefForPublishedVersion', () => {
+    let searchCrossRefForPublishedVersion: any;
+
+    beforeEach(() => {
+      searchCrossRefForPublishedVersion = createZotadataMethod('searchCrossRefForPublishedVersion', {
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+    });
+
+    it('should exclude arXiv container from results', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.arxivMatch);
+      const item = createMockItem({ title: 'Published Version of arXiv Paper' });
+      const result = await searchCrossRefForPublishedVersion(item);
+      expect(result).toBeDefined();
+    });
+
+    it('should require 0.9 title similarity', async () => {
+      registerFixture('crossref.org/works', crossrefFixtures.singleWork);
+      const item = createMockItem({ title: 'Test Paper Title' });
+      const result = await searchCrossRefForPublishedVersion(item);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/zotadata/arxiv-processing.test.ts
+++ b/tests/unit/zotadata/arxiv-processing.test.ts
@@ -1,0 +1,731 @@
+// tests/unit/zotadata/arxiv-processing.test.ts
+// Tests for arXiv processing pipeline functions in zotadata.js
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { createMockHTTP, registerFixture, clearFixtures } from '../../__mocks__/zotero-http';
+import { crossrefFixtures } from '../../__mocks__/fixtures/crossref';
+import { semanticscholarFixtures } from '../../__mocks__/fixtures/semanticscholar';
+
+describe('arXiv Processing Pipeline', () => {
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    clearCache();
+    clearFixtures();
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      HTTP_request: mockHTTP.request,
+      Utilities: {
+        cleanDOI: (d: string) => d ? d.trim().toLowerCase() : d,
+      },
+      Date: {
+        strToDate: (d: string) => ({ year: d?.match(/\d{4}/)?.[0] }),
+      },
+      ItemTypes: {
+        getName: vi.fn((typeID: number) => {
+          // Map type IDs to names
+          const typeMap: Record<number, string> = {
+            1: 'journalArticle',
+            2: 'book',
+            3: 'conferencePaper',
+            4: 'preprint',
+          };
+          return typeMap[typeID] || 'journalArticle';
+        }),
+        getID: vi.fn((name: string) => {
+          // Map names to type IDs
+          const idMap: Record<string, number> = {
+            'journalArticle': 1,
+            'book': 2,
+            'conferencePaper': 3,
+            'preprint': 4,
+          };
+          return idMap[name] || 1;
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearFixtures();
+  });
+
+  describe('processArxivItem', () => {
+    let processArxivItem: any;
+    let mockIsArxivItem: ReturnType<typeof vi.fn>;
+    let mockFindPublishedVersion: ReturnType<typeof vi.fn>;
+    let mockUpdateItemAsPublishedVersion: ReturnType<typeof vi.fn>;
+    let mockConvertToPreprint: ReturnType<typeof vi.fn>;
+    let mockItemHasPDF: ReturnType<typeof vi.fn>;
+    let mockDownloadPublishedVersion: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockIsArxivItem = vi.fn().mockReturnValue(true);
+      mockFindPublishedVersion = vi.fn().mockResolvedValue(null);
+      mockUpdateItemAsPublishedVersion = vi.fn().mockResolvedValue(undefined);
+      mockConvertToPreprint = vi.fn().mockResolvedValue(undefined);
+      mockItemHasPDF = vi.fn().mockResolvedValue(false);
+      mockDownloadPublishedVersion = vi.fn().mockResolvedValue(undefined);
+
+      processArxivItem = createZotadataMethod('processArxivItem', {
+        isArxivItem: mockIsArxivItem,
+        findPublishedVersion: mockFindPublishedVersion,
+        updateItemAsPublishedVersion: mockUpdateItemAsPublishedVersion,
+        convertToPreprint: mockConvertToPreprint,
+        itemHasPDF: mockItemHasPDF,
+        downloadPublishedVersion: mockDownloadPublishedVersion,
+      });
+    });
+
+    it('should process arXiv item with published version found', async () => {
+      mockFindPublishedVersion.mockResolvedValue('10.1000/published.doi');
+
+      const item = createMockItem({
+        title: 'Test arXiv Paper',
+        publicationTitle: 'arXiv',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await processArxivItem(item);
+
+      expect(result.processed).toBe(true);
+      expect(result.foundPublished).toBe(true);
+      expect(result.converted).toBe(false);
+      expect(mockFindPublishedVersion).toHaveBeenCalledWith(item);
+      expect(mockUpdateItemAsPublishedVersion).toHaveBeenCalledWith(item, '10.1000/published.doi');
+      expect(mockConvertToPreprint).not.toHaveBeenCalled();
+      expect(item.addTag).toHaveBeenCalledWith('Updated to Published Version', 1);
+    });
+
+    it('should convert to preprint when no published version found', async () => {
+      mockFindPublishedVersion.mockResolvedValue(null);
+
+      const item = createMockItem({
+        title: 'Test arXiv Paper',
+        publicationTitle: 'arXiv',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await processArxivItem(item);
+
+      expect(result.processed).toBe(true);
+      expect(result.foundPublished).toBe(false);
+      expect(result.converted).toBe(true);
+      expect(mockFindPublishedVersion).toHaveBeenCalledWith(item);
+      expect(mockConvertToPreprint).toHaveBeenCalledWith(item);
+      expect(mockUpdateItemAsPublishedVersion).not.toHaveBeenCalled();
+    });
+
+    it('should skip non-arXiv items', async () => {
+      mockIsArxivItem.mockReturnValue(false);
+
+      const item = createMockItem({
+        title: 'Regular Journal Article',
+        publicationTitle: 'Nature',
+      });
+
+      const result = await processArxivItem(item);
+
+      expect(result.processed).toBe(false);
+      expect(mockFindPublishedVersion).not.toHaveBeenCalled();
+      expect(mockConvertToPreprint).not.toHaveBeenCalled();
+    });
+
+    it('should add error tag when processing fails', async () => {
+      mockFindPublishedVersion.mockRejectedValue(new Error('Network error'));
+
+      const item = createMockItem({
+        title: 'Test arXiv Paper',
+        publicationTitle: 'arXiv',
+      });
+
+      const result = await processArxivItem(item);
+
+      expect(result.processed).toBe(false);
+      expect(item.addTag).toHaveBeenCalledWith('arXiv Process Error', 1);
+    });
+
+    it('should not convert non-journalArticle items when no published version', async () => {
+      mockFindPublishedVersion.mockResolvedValue(null);
+
+      const item = createMockItem({
+        title: 'Test arXiv Paper',
+        publicationTitle: 'arXiv',
+      });
+      item.itemTypeID = 3; // conferencePaper
+
+      const result = await processArxivItem(item);
+
+      expect(result.processed).toBe(true);
+      expect(result.converted).toBe(false);
+      expect(mockConvertToPreprint).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findPublishedVersion', () => {
+    let findPublishedVersion: any;
+    let mockExtractArxivId: ReturnType<typeof vi.fn>;
+    let mockSearchCrossRefByArxivId: ReturnType<typeof vi.fn>;
+    let mockSearchCrossRefForPublishedVersion: ReturnType<typeof vi.fn>;
+    let mockSearchSemanticScholarForPublishedVersion: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockExtractArxivId = vi.fn().mockReturnValue(null);
+      mockSearchCrossRefByArxivId = vi.fn().mockResolvedValue(null);
+      mockSearchCrossRefForPublishedVersion = vi.fn().mockResolvedValue(null);
+      mockSearchSemanticScholarForPublishedVersion = vi.fn().mockResolvedValue(null);
+
+      findPublishedVersion = createZotadataMethod('findPublishedVersion', {
+        extractArxivId: mockExtractArxivId,
+        searchCrossRefByArxivId: mockSearchCrossRefByArxivId,
+        searchCrossRefForPublishedVersion: mockSearchCrossRefForPublishedVersion,
+        searchSemanticScholarForPublishedVersion: mockSearchSemanticScholarForPublishedVersion,
+      });
+    });
+
+    it('should find DOI via arXiv ID search', async () => {
+      mockExtractArxivId.mockReturnValue('2301.12345');
+      mockSearchCrossRefByArxivId.mockResolvedValue('10.1000/published.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+        extra: 'arXiv:2301.12345',
+      });
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe('10.1000/published.doi');
+      expect(mockSearchCrossRefByArxivId).toHaveBeenCalledWith('2301.12345');
+      // Should not call other strategies when arXiv ID search succeeds
+      expect(mockSearchCrossRefForPublishedVersion).not.toHaveBeenCalled();
+      expect(mockSearchSemanticScholarForPublishedVersion).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to CrossRef title search when arXiv ID search fails', async () => {
+      mockExtractArxivId.mockReturnValue('2301.12345');
+      mockSearchCrossRefByArxivId.mockResolvedValue(null);
+      mockSearchCrossRefForPublishedVersion.mockResolvedValue('10.2000/title.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+        extra: 'arXiv:2301.12345',
+      });
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe('10.2000/title.doi');
+      expect(mockSearchCrossRefByArxivId).toHaveBeenCalledWith('2301.12345');
+      expect(mockSearchCrossRefForPublishedVersion).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForPublishedVersion).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to Semantic Scholar when CrossRef title search fails', async () => {
+      mockExtractArxivId.mockReturnValue(null);
+      mockSearchCrossRefForPublishedVersion.mockResolvedValue(null);
+      mockSearchSemanticScholarForPublishedVersion.mockResolvedValue('10.3000/semantic.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe('10.3000/semantic.doi');
+      expect(mockSearchCrossRefByArxivId).not.toHaveBeenCalled();
+      expect(mockSearchCrossRefForPublishedVersion).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForPublishedVersion).toHaveBeenCalledWith(item);
+    });
+
+    it('should return null when all strategies fail', async () => {
+      mockExtractArxivId.mockReturnValue('2301.12345');
+      mockSearchCrossRefByArxivId.mockResolvedValue(null);
+      mockSearchCrossRefForPublishedVersion.mockResolvedValue(null);
+      mockSearchSemanticScholarForPublishedVersion.mockResolvedValue(null);
+
+      const item = createMockItem({
+        title: 'Unknown Paper',
+        extra: 'arXiv:2301.12345',
+      });
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchCrossRefByArxivId).toHaveBeenCalledWith('2301.12345');
+      expect(mockSearchCrossRefForPublishedVersion).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForPublishedVersion).toHaveBeenCalledWith(item);
+    });
+
+    it('should return null when item has no title', async () => {
+      const item = createMockItem({
+        title: '',
+      });
+      item.getField = vi.fn((fieldName: string) => fieldName === 'title' ? '' : '');
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchCrossRefByArxivId).not.toHaveBeenCalled();
+    });
+
+    it('should skip arXiv ID search when no arXiv ID is found', async () => {
+      mockExtractArxivId.mockReturnValue(null);
+      mockSearchCrossRefForPublishedVersion.mockResolvedValue('10.1000/title.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+
+      const result = await findPublishedVersion(item);
+
+      expect(result).toBe('10.1000/title.doi');
+      expect(mockSearchCrossRefByArxivId).not.toHaveBeenCalled();
+      expect(mockSearchCrossRefForPublishedVersion).toHaveBeenCalledWith(item);
+    });
+  });
+
+  describe('convertToPreprint', () => {
+    let convertToPreprint: any;
+
+    beforeEach(() => {
+      convertToPreprint = createZotadataMethod('convertToPreprint');
+    });
+
+    it('should change item type to preprint', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+        publicationTitle: 'Some Journal',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      await convertToPreprint(item);
+
+      expect(item.setType).toHaveBeenCalledWith(4); // preprint ID
+    });
+
+    it('should set repository field to arXiv when not present', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+        publicationTitle: 'Some Journal',
+      });
+      item.itemTypeID = 1;
+      item.getField = vi.fn((fieldName: string) => {
+        if (fieldName === 'repository') return '';
+        if (fieldName === 'publicationTitle') return 'Some Journal';
+        return '';
+      });
+
+      await convertToPreprint(item);
+
+      expect(item.setField).toHaveBeenCalledWith('repository', 'arXiv');
+    });
+
+    it('should clear publicationTitle field', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+        publicationTitle: 'Some Journal',
+      });
+      item.itemTypeID = 1;
+
+      await convertToPreprint(item);
+
+      expect(item.setField).toHaveBeenCalledWith('publicationTitle', '');
+    });
+
+    it('should add Converted to Preprint tag', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+        publicationTitle: 'Some Journal',
+      });
+      item.itemTypeID = 1;
+
+      await convertToPreprint(item);
+
+      expect(item.addTag).toHaveBeenCalledWith('Converted to Preprint', 1);
+    });
+
+    it('should save the item', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+        publicationTitle: 'Some Journal',
+      });
+      item.itemTypeID = 1;
+
+      await convertToPreprint(item);
+
+      expect(item.saveTx).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateItemAsPublishedVersion', () => {
+    let updateItemAsPublishedVersion: any;
+    let mockFetchCrossRefMetadata: ReturnType<typeof vi.fn>;
+    let mockUpdateItemWithMetadata: ReturnType<typeof vi.fn>;
+    let mockUpdateAttachmentsForPublishedVersion: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetchCrossRefMetadata = vi.fn().mockResolvedValue({
+        DOI: '10.1000/published.doi',
+        title: ['Published Paper'],
+        type: 'journal-article',
+      });
+      mockUpdateItemWithMetadata = vi.fn().mockResolvedValue(undefined);
+      mockUpdateAttachmentsForPublishedVersion = vi.fn().mockResolvedValue(undefined);
+
+      updateItemAsPublishedVersion = createZotadataMethod('updateItemAsPublishedVersion', {
+        fetchCrossRefMetadata: mockFetchCrossRefMetadata,
+        updateItemWithMetadata: mockUpdateItemWithMetadata,
+        updateAttachmentsForPublishedVersion: mockUpdateAttachmentsForPublishedVersion,
+      });
+    });
+
+    it('should convert to conferencePaper when VENUE format with conference venue', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      await updateItemAsPublishedVersion(item, 'VENUE:NeurIPS Conference|TITLE:Test Paper');
+
+      expect(item.setType).toHaveBeenCalledWith(3); // conferencePaper ID
+      expect(item.setField).toHaveBeenCalledWith('proceedingsTitle', 'NeurIPS Conference');
+      expect(item.setField).toHaveBeenCalledWith('repository', '');
+    });
+
+    it('should convert to journalArticle when VENUE format with non-conference venue', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 3; // conferencePaper
+      item.getField = vi.fn((fieldName: string) => {
+        if (fieldName === 'repository') return 'arXiv';
+        return '';
+      });
+
+      await updateItemAsPublishedVersion(item, 'VENUE:Nature|TITLE:Test Paper');
+
+      expect(item.setType).toHaveBeenCalledWith(1); // journalArticle ID
+      expect(item.setField).toHaveBeenCalledWith('publicationTitle', 'Nature');
+      expect(item.setField).toHaveBeenCalledWith('repository', '');
+    });
+
+    it('should handle DOI format and fetch CrossRef metadata', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 4; // preprint
+
+      await updateItemAsPublishedVersion(item, '10.1000/published.doi');
+
+      expect(mockFetchCrossRefMetadata).toHaveBeenCalledWith('10.1000/published.doi');
+      expect(item.setField).toHaveBeenCalledWith('DOI', '10.1000/published.doi');
+      expect(item.setField).toHaveBeenCalledWith('repository', '');
+      expect(mockUpdateItemWithMetadata).toHaveBeenCalledWith(item, expect.objectContaining({
+        DOI: '10.1000/published.doi',
+      }));
+    });
+
+    it('should convert to conferencePaper for proceedings-article type', async () => {
+      mockFetchCrossRefMetadata.mockResolvedValue({
+        DOI: '10.1000/proceedings.doi',
+        title: ['Conference Paper'],
+        type: 'proceedings-article',
+      });
+
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      await updateItemAsPublishedVersion(item, '10.1000/proceedings.doi');
+
+      expect(item.setType).toHaveBeenCalledWith(3); // conferencePaper ID
+    });
+
+    it('should handle error gracefully', async () => {
+      mockFetchCrossRefMetadata.mockResolvedValue(null);
+
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+
+      // Should not throw, just return early
+      await updateItemAsPublishedVersion(item, '10.1000/invalid.doi');
+
+      // Since metadata fetch failed, item should not be updated
+      expect(item.setField).not.toHaveBeenCalledWith('DOI', expect.anything());
+    });
+
+    it('should call updateAttachmentsForPublishedVersion', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1;
+
+      await updateItemAsPublishedVersion(item, 'VENUE:Nature|TITLE:Test Paper');
+
+      expect(mockUpdateAttachmentsForPublishedVersion).toHaveBeenCalledWith(item);
+    });
+
+    it('should recognize ICML as conference venue', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1;
+
+      await updateItemAsPublishedVersion(item, 'VENUE:ICML 2024|TITLE:Test Paper');
+
+      expect(item.setType).toHaveBeenCalledWith(3); // conferencePaper
+    });
+
+    it('should recognize ICLR as conference venue', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1;
+
+      await updateItemAsPublishedVersion(item, 'VENUE:ICLR 2024|TITLE:Test Paper');
+
+      expect(item.setType).toHaveBeenCalledWith(3); // conferencePaper
+    });
+
+    it('should recognize PROCEEDINGS in venue name', async () => {
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+      item.itemTypeID = 1;
+
+      await updateItemAsPublishedVersion(item, 'VENUE:Conference Proceedings|TITLE:Test Paper');
+
+      expect(item.setType).toHaveBeenCalledWith(3); // conferencePaper
+    });
+  });
+
+  describe('searchSemanticScholarForPublishedVersion', () => {
+    let searchSemanticScholarForPublishedVersion: any;
+    let mockSearchSemanticScholarExactPublished: ReturnType<typeof vi.fn>;
+    let mockSearchSemanticScholarRelaxedPublished: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockSearchSemanticScholarExactPublished = vi.fn().mockResolvedValue(null);
+      mockSearchSemanticScholarRelaxedPublished = vi.fn().mockResolvedValue(null);
+
+      searchSemanticScholarForPublishedVersion = createZotadataMethod(
+        'searchSemanticScholarForPublishedVersion',
+        {
+          searchSemanticScholarExactPublished: mockSearchSemanticScholarExactPublished,
+          searchSemanticScholarRelaxedPublished: mockSearchSemanticScholarRelaxedPublished,
+        }
+      );
+    });
+
+    it('should find DOI via exact search', async () => {
+      mockSearchSemanticScholarExactPublished.mockResolvedValue('10.1000/exact.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+        creators: [{ lastName: 'Smith', firstName: 'John' }],
+      });
+
+      const result = await searchSemanticScholarForPublishedVersion(item);
+
+      expect(result).toBe('10.1000/exact.doi');
+      expect(mockSearchSemanticScholarExactPublished).toHaveBeenCalledWith(item, 'Test Paper');
+      expect(mockSearchSemanticScholarRelaxedPublished).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to relaxed search when exact search fails', async () => {
+      mockSearchSemanticScholarExactPublished.mockResolvedValue(null);
+      mockSearchSemanticScholarRelaxedPublished.mockResolvedValue('10.2000/relaxed.doi');
+
+      const item = createMockItem({
+        title: 'Test Paper',
+      });
+
+      const result = await searchSemanticScholarForPublishedVersion(item);
+
+      expect(result).toBe('10.2000/relaxed.doi');
+      expect(mockSearchSemanticScholarExactPublished).toHaveBeenCalledWith(item, 'Test Paper');
+      expect(mockSearchSemanticScholarRelaxedPublished).toHaveBeenCalledWith(item, 'Test Paper');
+    });
+
+    it('should return null when both searches fail', async () => {
+      mockSearchSemanticScholarExactPublished.mockResolvedValue(null);
+      mockSearchSemanticScholarRelaxedPublished.mockResolvedValue(null);
+
+      const item = createMockItem({
+        title: 'Unknown Paper',
+      });
+
+      const result = await searchSemanticScholarForPublishedVersion(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchSemanticScholarExactPublished).toHaveBeenCalled();
+      expect(mockSearchSemanticScholarRelaxedPublished).toHaveBeenCalled();
+    });
+
+    it('should return null when item has no title', async () => {
+      const item = createMockItem({
+        title: '',
+      });
+      item.getField = vi.fn((fieldName: string) => fieldName === 'title' ? '' : '');
+
+      const result = await searchSemanticScholarForPublishedVersion(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchSemanticScholarExactPublished).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchSemanticScholarExactPublished (integration)', () => {
+    let searchSemanticScholarExactPublished: any;
+
+    beforeEach(() => {
+      searchSemanticScholarExactPublished = createZotadataMethod(
+        'searchSemanticScholarExactPublished',
+        {
+          titleSimilarity: createZotadataMethod('titleSimilarity'),
+        }
+      );
+    });
+
+    it('should exclude arXiv venue from results', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.arxivPaper);
+
+      const item = createMockItem({
+        title: 'arXiv Paper',
+      });
+
+      const result = await searchSemanticScholarExactPublished(item, 'arXiv Paper');
+
+      expect(result).toBe(null);
+    });
+
+    it('should find published version with high similarity threshold', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.publishedVersion);
+
+      const item = createMockItem({
+        title: 'Published Version',
+      });
+
+      const result = await searchSemanticScholarExactPublished(item, 'Published Version');
+
+      expect(result).toBe('10.1000/published.doi');
+    });
+
+    it('should return null for no results', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.noResults);
+
+      const item = createMockItem({
+        title: 'Nonexistent Paper',
+      });
+
+      const result = await searchSemanticScholarExactPublished(item, 'Nonexistent Paper');
+
+      expect(result).toBe(null);
+    });
+
+    it('should extract DOI from externalIds', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.singlePaper);
+
+      const item = createMockItem({
+        title: 'Test Paper Title',
+      });
+
+      const result = await searchSemanticScholarExactPublished(item, 'Test Paper Title');
+
+      expect(result).toBe('10.1000/test.doi');
+    });
+
+    it('should return VENUE format for papers without DOI', async () => {
+      const venueOnlyFixture = {
+        status: 200,
+        responseText: JSON.stringify({
+          data: [{
+            paperId: 'venue123',
+            title: 'Conference Paper Without DOI',
+            venue: 'NeurIPS 2024',
+            externalIds: {},
+          }],
+        }),
+        getResponseHeader: () => null,
+      };
+      registerFixture('api.semanticscholar.org', venueOnlyFixture);
+
+      const item = createMockItem({
+        title: 'Conference Paper Without DOI',
+      });
+
+      const result = await searchSemanticScholarExactPublished(item, 'Conference Paper Without DOI');
+
+      expect(result).toBe('VENUE:NeurIPS 2024|TITLE:Conference Paper Without DOI');
+    });
+  });
+
+  describe('searchSemanticScholarRelaxedPublished (integration)', () => {
+    let searchSemanticScholarRelaxedPublished: any;
+
+    beforeEach(() => {
+      searchSemanticScholarRelaxedPublished = createZotadataMethod(
+        'searchSemanticScholarRelaxedPublished',
+        {
+          titleSimilarity: createZotadataMethod('titleSimilarity'),
+        }
+      );
+    });
+
+    it('should exclude arXiv venue from results', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.arxivPaper);
+
+      const item = createMockItem({
+        title: 'arXiv Paper',
+      });
+
+      const result = await searchSemanticScholarRelaxedPublished(item, 'arXiv Paper');
+
+      expect(result).toBe(null);
+    });
+
+    it('should find published version with 0.9 similarity threshold', async () => {
+      registerFixture('api.semanticscholar.org', semanticscholarFixtures.publishedVersion);
+
+      const item = createMockItem({
+        title: 'Published Version',
+      });
+
+      const result = await searchSemanticScholarRelaxedPublished(item, 'Published Version');
+
+      expect(result).toBe('10.1000/published.doi');
+    });
+
+    it('should clean title for better matching', async () => {
+      // Use a title that will match with high similarity after cleaning
+      const matchingFixture = {
+        status: 200,
+        responseText: JSON.stringify({
+          data: [{
+            paperId: 'match123',
+            title: 'Test Paper Title: A Study', // Matches exactly
+            venue: 'Nature',
+            externalIds: { DOI: '10.1000/matching.doi' },
+          }],
+        }),
+        getResponseHeader: () => null,
+      };
+      registerFixture('api.semanticscholar.org', matchingFixture);
+
+      const item = createMockItem({
+        title: 'Test Paper Title: A Study',
+      });
+
+      // The relaxed search cleans the title before searching
+      const result = await searchSemanticScholarRelaxedPublished(item, 'Test Paper Title: A Study');
+
+      // Should find a match due to relaxed matching
+      expect(result).toBe('10.1000/matching.doi');
+    });
+  });
+});

--- a/tests/unit/zotadata/batch-processing.test.ts
+++ b/tests/unit/zotadata/batch-processing.test.ts
@@ -1,0 +1,443 @@
+// tests/unit/zotadata/batch-processing.test.ts
+// Tests for batch processing functions in zotadata.js
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem, createMockAttachment, resetMockCounters } from '../../__mocks__/zotero-items';
+
+describe('processBatch', () => {
+  let processBatch: any;
+
+  beforeEach(() => {
+    clearCache();
+    resetMockCounters();
+
+    // Mock Zotero global for progress window
+    (globalThis as any).Zotero = {
+      getMainWindow: vi.fn().mockReturnValue({
+        Zotero: {
+          ProgressWindow: vi.fn().mockImplementation(() => ({
+            changeHeadline: vi.fn(),
+            show: vi.fn(),
+            close: vi.fn(),
+            _progressIndicators: [{
+              setProgress: vi.fn(),
+              setText: vi.fn(),
+            }],
+          })),
+        },
+      }),
+    };
+
+    processBatch = createZotadataMethod('processBatch', {
+      log: vi.fn(),
+      createProgressWindow: vi.fn().mockReturnValue(null),
+      updateProgressWindow: vi.fn(),
+      closeProgressWindow: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should process items in batches', async () => {
+    const items = Array(10).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await processBatch(items, processFn, { batchSize: 3 });
+
+    expect(result.totalProcessed).toBe(10);
+    expect(result.success).toBe(true);
+  });
+
+  it('should handle errors in processing', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const processFn = vi.fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Failed'));
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result.errorCount).toBe(1);
+  });
+
+  it('should call progress callback', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const onProgress = vi.fn();
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, {
+      batchSize: 1,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalled();
+  });
+
+  it('should respect batch size setting', async () => {
+    const items = Array(6).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, { batchSize: 2 });
+
+    // Verify processFn was called for all items
+    expect(processFn).toHaveBeenCalledTimes(6);
+  });
+
+  it('should add delay between batches', async () => {
+    const items = Array(4).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+    const delayBetweenBatches = 50;
+
+    const start = Date.now();
+    await processBatch(items, processFn, { batchSize: 2, delayBetweenBatches });
+    const duration = Date.now() - start;
+
+    // Should have at least one delay between batches
+    expect(duration).toBeGreaterThanOrEqual(delayBetweenBatches - 10); // Allow small margin
+  });
+
+  it('should return correct result structure', async () => {
+    const items = [createMockItem({ id: 1 })];
+    const processFn = vi.fn().mockResolvedValue({ data: 'test' });
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result).toHaveProperty('success');
+    expect(result).toHaveProperty('totalProcessed');
+    expect(result).toHaveProperty('errorCount');
+    expect(result).toHaveProperty('results');
+    expect(Array.isArray(result.results)).toBe(true);
+  });
+
+  it('should collect errors without stopping batch', async () => {
+    const items = Array(3).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Failed'))
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await processBatch(items, processFn, { batchSize: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.errorCount).toBe(1);
+    expect(result.totalProcessed).toBe(3);
+  });
+
+  it('should call onBatchComplete callback after each batch', async () => {
+    const items = Array(4).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const onBatchComplete = vi.fn();
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, { batchSize: 2, onBatchComplete });
+
+    // Should be called twice (2 batches)
+    expect(onBatchComplete).toHaveBeenCalledTimes(2);
+  });
+
+  it('should indicate last batch in onBatchComplete callback', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const onBatchComplete = vi.fn();
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, { batchSize: 2, onBatchComplete });
+
+    // Last argument should be true (isLastBatch)
+    expect(onBatchComplete).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      true
+    );
+  });
+
+  it('should process items concurrently within a batch', async () => {
+    const items = Array(3).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processingOrder: number[] = [];
+    const processFn = vi.fn().mockImplementation(async (item: any) => {
+      processingOrder.push(item.id);
+      // Small delay to simulate async work
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return { success: true };
+    });
+
+    await processBatch(items, processFn, { batchSize: 3 });
+
+    // All items should have been processed
+    expect(processFn).toHaveBeenCalledTimes(3);
+    expect(processingOrder.length).toBe(3);
+  });
+
+  it('should calculate success rate correctly', async () => {
+    const items = Array(4).fill(null).map((_, i) => createMockItem({ id: i + 1 }));
+    const processFn = vi.fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('Failed'))
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await processBatch(items, processFn, { batchSize: 2 });
+
+    expect(result.successCount).toBe(3);
+    expect(result.errorCount).toBe(1);
+    expect(result.successRate).toBe(75); // 3 out of 4
+  });
+
+  it('should pass item index to processFn', async () => {
+    const items = [createMockItem({ id: 1 }), createMockItem({ id: 2 })];
+    const processFn = vi.fn().mockResolvedValue({ success: true });
+
+    await processBatch(items, processFn, { batchSize: 2 });
+
+    // processFn should be called with (item, index)
+    expect(processFn).toHaveBeenCalledWith(items[0], 0);
+    expect(processFn).toHaveBeenCalledWith(items[1], 1);
+  });
+});
+
+describe('simpleAttachmentCheckBatch', () => {
+  let simpleAttachmentCheckBatch: any;
+
+  beforeEach(() => {
+    clearCache();
+    resetMockCounters();
+
+    // Mock Zotero global with attachment link modes
+    (globalThis as any).Zotero = {
+      Attachments: {
+        LINK_MODE_LINKED_URL: 1,
+        LINK_MODE_IMPORTED_FILE: 2,
+        LINK_MODE_LINKED_FILE: 3,
+      },
+      Items: {
+        get: vi.fn(),
+      },
+    };
+
+    simpleAttachmentCheckBatch = createZotadataMethod('simpleAttachmentCheckBatch', {
+      log: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return stats for item with no attachments', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([]);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.weblinks).toBe(0);
+    expect(result.processed).toBe(1);
+  });
+
+  it('should remove broken file attachments', async () => {
+    const brokenAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: false,
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(brokenAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.removed).toBe(1);
+    expect(brokenAttachment.eraseTx).toHaveBeenCalled();
+  });
+
+  it('should keep weblink attachments', async () => {
+    const weblinkAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 1, // LINKED_URL
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(weblinkAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.weblinks).toBe(1);
+    expect(result.valid).toBe(1);
+    expect(weblinkAttachment.eraseTx).not.toHaveBeenCalled();
+  });
+
+  it('should count valid file attachments', async () => {
+    const validAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2, // IMPORTED_FILE
+      fileExists: true,
+      filePath: '/path/to/file.pdf',
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(validAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(1);
+    expect(result.removed).toBe(0);
+  });
+
+  it('should handle errors gracefully', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockImplementation(() => {
+      throw new Error('Test error');
+    });
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.errors).toBe(1);
+    expect(result.processed).toBe(1);
+  });
+
+  it('should handle missing attachment object', async () => {
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([999]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(null);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    // Should skip the missing attachment without error
+    expect(result.valid).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it('should handle attachment with no file path', async () => {
+    const noPathAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2, // IMPORTED_FILE
+      filePath: null,
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(noPathAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.removed).toBe(1);
+    expect(noPathAttachment.eraseTx).toHaveBeenCalled();
+  });
+
+  it('should handle linked file attachments', async () => {
+    const linkedAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 3, // LINKED_FILE
+      fileExists: true,
+      filePath: '/path/to/linked/file.pdf',
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(linkedAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(1);
+    expect(result.removed).toBe(0);
+  });
+
+  it('should process multiple attachments', async () => {
+    const validAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2,
+      fileExists: true,
+      filePath: '/path/to/file.pdf',
+    });
+    const brokenAttachment = createMockAttachment({
+      id: 2,
+      linkMode: 2,
+      fileExists: false,
+    });
+    const weblinkAttachment = createMockAttachment({
+      id: 3,
+      linkMode: 1, // LINKED_URL
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1, 2, 3]);
+    (globalThis as any).Zotero.Items.get = vi.fn()
+      .mockImplementation((id: number) => {
+        if (id === 1) return validAttachment;
+        if (id === 2) return brokenAttachment;
+        if (id === 3) return weblinkAttachment;
+        return null;
+      });
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    expect(result.valid).toBe(2); // valid file + weblink
+    expect(result.removed).toBe(1); // broken file
+    expect(result.weblinks).toBe(1);
+  });
+
+  it('should handle unknown attachment link mode', async () => {
+    const unknownAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 99, // Unknown mode
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(unknownAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    // Unknown attachment types are kept
+    expect(result.valid).toBe(1);
+    expect(result.removed).toBe(0);
+  });
+
+  it('should handle file check errors', async () => {
+    const errorAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2,
+      filePath: '/path/to/file.pdf',
+      fileExists: true,
+    });
+    // Override getFilePath to throw
+    errorAttachment.getFilePath = vi.fn().mockImplementation(() => {
+      throw new Error('File access error');
+    });
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(errorAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    // Error accessing file should result in removal
+    expect(result.removed).toBe(1);
+  });
+
+  it('should handle erase errors gracefully', async () => {
+    const brokenAttachment = createMockAttachment({
+      id: 1,
+      linkMode: 2,
+      fileExists: false,
+    });
+    // Make eraseTx throw
+    brokenAttachment.eraseTx = vi.fn().mockRejectedValue(new Error('Erase failed'));
+
+    const item = createMockItem();
+    item.getAttachments = vi.fn().mockReturnValue([1]);
+    (globalThis as any).Zotero.Items.get = vi.fn().mockReturnValue(brokenAttachment);
+
+    const result = await simpleAttachmentCheckBatch(item);
+
+    // When erase fails, removed is not incremented (error is caught and logged)
+    expect(result.removed).toBe(0);
+    // But eraseTx should have been attempted
+    expect(brokenAttachment.eraseTx).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/zotadata/discovery.test.ts
+++ b/tests/unit/zotadata/discovery.test.ts
@@ -1,0 +1,271 @@
+// tests/unit/zotadata/discovery.test.ts
+// Tests for discovery orchestration functions in zotadata.js
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+
+describe('Discovery Functions', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('discoverDOI', () => {
+    let discoverDOI: (item: any) => Promise<string | null>;
+    let mockSearchCrossRefForDOI: ReturnType<typeof vi.fn>;
+    let mockSearchOpenAlexForDOI: ReturnType<typeof vi.fn>;
+    let mockSearchSemanticScholarForDOI: ReturnType<typeof vi.fn>;
+    let mockSearchDBLPForDOI: ReturnType<typeof vi.fn>;
+    let mockSearchGoogleScholarForDOI: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      // Create mock functions for subordinate search methods
+      mockSearchCrossRefForDOI = vi.fn().mockResolvedValue(null);
+      mockSearchOpenAlexForDOI = vi.fn().mockResolvedValue(null);
+      mockSearchSemanticScholarForDOI = vi.fn().mockResolvedValue(null);
+      mockSearchDBLPForDOI = vi.fn().mockResolvedValue(null);
+      mockSearchGoogleScholarForDOI = vi.fn().mockResolvedValue(null);
+
+      discoverDOI = createZotadataMethod('discoverDOI', {
+        searchCrossRefForDOI: mockSearchCrossRefForDOI,
+        searchOpenAlexForDOI: mockSearchOpenAlexForDOI,
+        searchSemanticScholarForDOI: mockSearchSemanticScholarForDOI,
+        searchDBLPForDOI: mockSearchDBLPForDOI,
+        searchGoogleScholarForDOI: mockSearchGoogleScholarForDOI,
+      });
+    });
+
+    it('should return DOI from CrossRef when found first', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue('10.1000/crossref.doi');
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe('10.1000/crossref.doi');
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledTimes(1);
+      // Should not call other search functions when CrossRef succeeds
+      expect(mockSearchOpenAlexForDOI).not.toHaveBeenCalled();
+      expect(mockSearchSemanticScholarForDOI).not.toHaveBeenCalled();
+      expect(mockSearchDBLPForDOI).not.toHaveBeenCalled();
+      expect(mockSearchGoogleScholarForDOI).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to OpenAlex when CrossRef returns null', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue(null);
+      mockSearchOpenAlexForDOI.mockResolvedValue('10.2000/openalex.doi');
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe('10.2000/openalex.doi');
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenAlexForDOI).toHaveBeenCalledWith(item);
+      // Should not call remaining search functions when OpenAlex succeeds
+      expect(mockSearchSemanticScholarForDOI).not.toHaveBeenCalled();
+      expect(mockSearchDBLPForDOI).not.toHaveBeenCalled();
+      expect(mockSearchGoogleScholarForDOI).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to Semantic Scholar when CrossRef and OpenAlex return null', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue(null);
+      mockSearchOpenAlexForDOI.mockResolvedValue(null);
+      mockSearchSemanticScholarForDOI.mockResolvedValue('10.3000/semanticscholar.doi');
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe('10.3000/semanticscholar.doi');
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenAlexForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForDOI).toHaveBeenCalledWith(item);
+      // Should not call remaining search functions when Semantic Scholar succeeds
+      expect(mockSearchDBLPForDOI).not.toHaveBeenCalled();
+      expect(mockSearchGoogleScholarForDOI).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to DBLP when CrossRef, OpenAlex, and Semantic Scholar return null', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue(null);
+      mockSearchOpenAlexForDOI.mockResolvedValue(null);
+      mockSearchSemanticScholarForDOI.mockResolvedValue(null);
+      mockSearchDBLPForDOI.mockResolvedValue('10.4000/dblp.doi');
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe('10.4000/dblp.doi');
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenAlexForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchDBLPForDOI).toHaveBeenCalledWith(item);
+      // Should not call Google Scholar when DBLP succeeds
+      expect(mockSearchGoogleScholarForDOI).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to Google Scholar when all other sources return null', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue(null);
+      mockSearchOpenAlexForDOI.mockResolvedValue(null);
+      mockSearchSemanticScholarForDOI.mockResolvedValue(null);
+      mockSearchDBLPForDOI.mockResolvedValue(null);
+      mockSearchGoogleScholarForDOI.mockResolvedValue('10.5000/googlescholar.doi');
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe('10.5000/googlescholar.doi');
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenAlexForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchDBLPForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchGoogleScholarForDOI).toHaveBeenCalledWith(item);
+    });
+
+    it('should return null when all sources fail', async () => {
+      mockSearchCrossRefForDOI.mockResolvedValue(null);
+      mockSearchOpenAlexForDOI.mockResolvedValue(null);
+      mockSearchSemanticScholarForDOI.mockResolvedValue(null);
+      mockSearchDBLPForDOI.mockResolvedValue(null);
+      mockSearchGoogleScholarForDOI.mockResolvedValue(null);
+
+      const item = createMockItem({ title: 'Unknown Paper' });
+      const result = await discoverDOI(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchCrossRefForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenAlexForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchSemanticScholarForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchDBLPForDOI).toHaveBeenCalledWith(item);
+      expect(mockSearchGoogleScholarForDOI).toHaveBeenCalledWith(item);
+    });
+
+    it('should call search functions in correct order', async () => {
+      const callOrder: string[] = [];
+
+      mockSearchCrossRefForDOI.mockImplementation(async () => {
+        callOrder.push('crossref');
+        return null;
+      });
+      mockSearchOpenAlexForDOI.mockImplementation(async () => {
+        callOrder.push('openalex');
+        return null;
+      });
+      mockSearchSemanticScholarForDOI.mockImplementation(async () => {
+        callOrder.push('semanticscholar');
+        return null;
+      });
+      mockSearchDBLPForDOI.mockImplementation(async () => {
+        callOrder.push('dblp');
+        return null;
+      });
+      mockSearchGoogleScholarForDOI.mockImplementation(async () => {
+        callOrder.push('googlescholar');
+        return null;
+      });
+
+      const item = createMockItem({ title: 'Test Paper' });
+      await discoverDOI(item);
+
+      expect(callOrder).toEqual([
+        'crossref',
+        'openalex',
+        'semanticscholar',
+        'dblp',
+        'googlescholar',
+      ]);
+    });
+
+    it('should propagate errors from search functions', async () => {
+      mockSearchCrossRefForDOI.mockRejectedValue(new Error('Network error'));
+
+      const item = createMockItem({ title: 'Test Paper' });
+
+      // The function doesn't have try-catch, so it propagates the error
+      await expect(discoverDOI(item)).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('discoverISBN', () => {
+    let discoverISBN: (item: any) => Promise<string | null>;
+    let mockSearchOpenLibraryForISBN: ReturnType<typeof vi.fn>;
+    let mockSearchGoogleBooksForISBN: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      // Create mock functions for subordinate search methods
+      mockSearchOpenLibraryForISBN = vi.fn().mockResolvedValue(null);
+      mockSearchGoogleBooksForISBN = vi.fn().mockResolvedValue(null);
+
+      discoverISBN = createZotadataMethod('discoverISBN', {
+        searchOpenLibraryForISBN: mockSearchOpenLibraryForISBN,
+        searchGoogleBooksForISBN: mockSearchGoogleBooksForISBN,
+      });
+    });
+
+    it('should return ISBN from OpenLibrary when found first', async () => {
+      mockSearchOpenLibraryForISBN.mockResolvedValue('978-0-123456-78-9');
+
+      const item = createMockItem({ title: 'Test Book' });
+      const result = await discoverISBN(item);
+
+      expect(result).toBe('978-0-123456-78-9');
+      expect(mockSearchOpenLibraryForISBN).toHaveBeenCalledWith(item);
+      expect(mockSearchOpenLibraryForISBN).toHaveBeenCalledTimes(1);
+      // Should not call Google Books when OpenLibrary succeeds
+      expect(mockSearchGoogleBooksForISBN).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to Google Books when OpenLibrary returns null', async () => {
+      mockSearchOpenLibraryForISBN.mockResolvedValue(null);
+      mockSearchGoogleBooksForISBN.mockResolvedValue('978-1-234567-89-0');
+
+      const item = createMockItem({ title: 'Test Book' });
+      const result = await discoverISBN(item);
+
+      expect(result).toBe('978-1-234567-89-0');
+      expect(mockSearchOpenLibraryForISBN).toHaveBeenCalledWith(item);
+      expect(mockSearchGoogleBooksForISBN).toHaveBeenCalledWith(item);
+    });
+
+    it('should return null when all sources fail', async () => {
+      mockSearchOpenLibraryForISBN.mockResolvedValue(null);
+      mockSearchGoogleBooksForISBN.mockResolvedValue(null);
+
+      const item = createMockItem({ title: 'Unknown Book' });
+      const result = await discoverISBN(item);
+
+      expect(result).toBe(null);
+      expect(mockSearchOpenLibraryForISBN).toHaveBeenCalledWith(item);
+      expect(mockSearchGoogleBooksForISBN).toHaveBeenCalledWith(item);
+    });
+
+    it('should call search functions in correct order', async () => {
+      const callOrder: string[] = [];
+
+      mockSearchOpenLibraryForISBN.mockImplementation(async () => {
+        callOrder.push('openlibrary');
+        return null;
+      });
+      mockSearchGoogleBooksForISBN.mockImplementation(async () => {
+        callOrder.push('googlebooks');
+        return null;
+      });
+
+      const item = createMockItem({ title: 'Test Book' });
+      await discoverISBN(item);
+
+      expect(callOrder).toEqual(['openlibrary', 'googlebooks']);
+    });
+
+    it('should propagate errors from search functions', async () => {
+      mockSearchOpenLibraryForISBN.mockRejectedValue(new Error('API error'));
+
+      const item = createMockItem({ title: 'Test Book' });
+
+      // The function doesn't have try-catch, so it propagates the error
+      await expect(discoverISBN(item)).rejects.toThrow('API error');
+    });
+  });
+});

--- a/tests/unit/zotadata/extractors.test.ts
+++ b/tests/unit/zotadata/extractors.test.ts
@@ -1,0 +1,304 @@
+// tests/unit/zotadata/extractors.test.ts
+// Tests for extractor functions in zotadata.js
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+
+// Mock Zotero.Utilities
+(globalThis as any).Zotero = {
+  Utilities: {
+    cleanDOI: (doi: string) => doi.trim().toLowerCase(),
+    cleanISBN: (isbn: string) => isbn.replace(/[^0-9X]/gi, ''),
+  },
+};
+
+describe('extractDOI', () => {
+  let extractDOI: (item: any) => string | null;
+
+  beforeEach(() => {
+    clearCache();
+    extractDOI = createZotadataMethod('extractDOI');
+  });
+
+  it('should extract DOI from DOI field', () => {
+    const item = createMockItem({ DOI: '10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from URL with doi.org pattern', () => {
+    const item = createMockItem({ url: 'https://doi.org/10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from URL with dx.doi.org pattern', () => {
+    const item = createMockItem({ url: 'https://dx.doi.org/10.1000/test.doi' });
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from extra field', () => {
+    // The regex in code: /DOI[:\-\s]*([10]\.\d{4,}\/[^\s]+)/i
+    // Note: [10] matches '1' or '0', so '10.' is not matched as a unit
+    // This test documents current behavior - DOI extraction from extra is limited
+    const item = createMockItem({ extra: 'DOI: 10.1000/test.doi' });
+    // The implementation's regex [10]\.\d{4,} only matches single digit 1 or 0 before dot
+    // So '10.' won't match. This test documents that behavior.
+    expect(extractDOI(item)).toBe(null);
+  });
+
+  it('should handle various DOI formats', () => {
+    const item = createMockItem({ DOI: '10.1234/abc.def-ghi_123' });
+    expect(extractDOI(item)).toBe('10.1234/abc.def-ghi_123');
+  });
+
+  it('should return null for item without DOI', () => {
+    const item = createMockItem({ title: 'No DOI Here' });
+    expect(extractDOI(item)).toBe(null);
+  });
+
+  it('should clean DOI using Zotero.Utilities.cleanDOI', () => {
+    const item = createMockItem({ DOI: '  10.1000/TEST.DOI  ' });
+    // cleanDOI trims and lowercases
+    expect(extractDOI(item)).toBe('10.1000/test.doi');
+  });
+
+  it('should extract DOI from URL with direct DOI pattern', () => {
+    const item = createMockItem({ url: 'https://example.com/paper/10.1234/paper.doi' });
+    expect(extractDOI(item)).toBe('10.1234/paper.doi');
+  });
+
+  it('should extract DOI from extra field with DOI: prefix', () => {
+    // The regex in code: /DOI[:\-\s]*([10]\.\d{4,}\/[^\s]+)/i
+    // Note: [10] matches single char '1' or '0', not '10' - this is a bug in the implementation
+    // '10.1000' won't match because after matching '1', the next char '0' doesn't match '\.'
+    const item = createMockItem({ extra: 'DOI: 10.1000/test.doi\nSome other info' });
+    expect(extractDOI(item)).toBe(null);
+  });
+
+  it('should extract DOI from extra field with hyphen separator', () => {
+    // Same regex limitation as above
+    const item = createMockItem({ extra: 'DOI- 10.1000/test.doi' });
+    expect(extractDOI(item)).toBe(null);
+  });
+
+  it('should prioritize DOI field over URL', () => {
+    const item = createMockItem({
+      DOI: '10.1000/primary.doi',
+      url: 'https://doi.org/10.1000/secondary.doi'
+    });
+    expect(extractDOI(item)).toBe('10.1000/primary.doi');
+  });
+
+  it('should prioritize URL over extra field', () => {
+    const item = createMockItem({
+      url: 'https://doi.org/10.1000/url.doi',
+      extra: 'DOI: 10.1000/extra.doi'
+    });
+    expect(extractDOI(item)).toBe('10.1000/url.doi');
+  });
+});
+
+describe('extractISBN', () => {
+  let extractISBN: (item: any) => string | null;
+
+  beforeEach(() => {
+    clearCache();
+    extractISBN = createZotadataMethod('extractISBN');
+  });
+
+  it('should extract ISBN-13 from ISBN field', () => {
+    const item = createMockItem({ ISBN: '978-0-123456-78-9' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should extract ISBN-10 from ISBN field', () => {
+    const item = createMockItem({ ISBN: '0-123456-78-X' });
+    expect(extractISBN(item)).toBe('012345678X');
+  });
+
+  it('should extract ISBN from extra field', () => {
+    const item = createMockItem({ extra: 'ISBN: 9780123456789' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should return null for item without ISBN', () => {
+    const item = createMockItem({ title: 'No ISBN' });
+    expect(extractISBN(item)).toBe(null);
+  });
+
+  it('should clean ISBN using Zotero.Utilities.cleanISBN', () => {
+    const item = createMockItem({ ISBN: '978-0-123-456-78-9' });
+    // cleanISBN removes hyphens and non-digit/X characters
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should extract ISBN from extra field with various formats', () => {
+    const item = createMockItem({ extra: 'ISBN: 978-0-123456-78-9\nPublisher: Test' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should prioritize ISBN field over extra field', () => {
+    const item = createMockItem({
+      ISBN: '978-0-123456-78-9',
+      extra: 'ISBN: 978-1-234567-89-0'
+    });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+
+  it('should handle ISBN-10 with check digit X', () => {
+    const item = createMockItem({ ISBN: '0-201-63361-X' });
+    expect(extractISBN(item)).toBe('020163361X');
+  });
+
+  it('should handle ISBN-10 with lowercase x', () => {
+    const item = createMockItem({ ISBN: '0-201-63361-x' });
+    // cleanISBN preserves the original case of X
+    expect(extractISBN(item)).toBe('020163361x');
+  });
+
+  it('should extract ISBN from extra field with hyphen separator', () => {
+    const item = createMockItem({ extra: 'ISBN- 9780123456789' });
+    expect(extractISBN(item)).toBe('9780123456789');
+  });
+});
+
+describe('extractArxivId', () => {
+  let extractArxivId: (item: any) => string | null;
+
+  beforeEach(() => {
+    clearCache();
+    extractArxivId = createZotadataMethod('extractArxivId');
+  });
+
+  it('should extract arXiv ID from extra field', () => {
+    const item = createMockItem({ extra: 'arXiv:2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should extract arXiv ID from URL', () => {
+    const item = createMockItem({ url: 'https://arxiv.org/abs/2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should return null for non-arXiv item', () => {
+    const item = createMockItem({ title: 'Regular Paper' });
+    expect(extractArxivId(item)).toBe(null);
+  });
+
+  it('should extract arXiv ID from extra field with space separator', () => {
+    const item = createMockItem({ extra: 'arXiv 2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should extract arXiv ID from extra field with longer ID', () => {
+    // The regex /\d{4}\.\d{4,5}/ captures 4-5 digits after the dot
+    // 123456 has 6 digits, but regex only captures 4-5, so it captures first 5
+    const item = createMockItem({ extra: 'arXiv:2301.123456' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should extract arXiv ID from URL with pdf path', () => {
+    const item = createMockItem({ url: 'https://arxiv.org/abs/2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should extract arXiv ID case-insensitively', () => {
+    const item = createMockItem({ extra: 'ARXIV:2301.12345' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+
+  it('should prioritize extra field over URL', () => {
+    const item = createMockItem({
+      extra: 'arXiv:2301.11111',
+      url: 'https://arxiv.org/abs/2301.22222'
+    });
+    expect(extractArxivId(item)).toBe('2301.11111');
+  });
+
+  it('should handle arXiv ID with extra content in extra field', () => {
+    const item = createMockItem({ extra: 'arXiv:2301.12345\nPublished: Journal Name' });
+    expect(extractArxivId(item)).toBe('2301.12345');
+  });
+});
+
+describe('isArxivItem', () => {
+  let isArxivItem: (item: any) => boolean;
+
+  beforeEach(() => {
+    clearCache();
+    isArxivItem = createZotadataMethod('isArxivItem');
+  });
+
+  it('should detect arXiv from publicationTitle', () => {
+    const item = createMockItem({ publicationTitle: 'arXiv' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from URL', () => {
+    const item = createMockItem({ url: 'https://arxiv.org/abs/2301.12345' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from extra field', () => {
+    const item = createMockItem({ extra: 'arXiv:2301.12345' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from title', () => {
+    const item = createMockItem({ title: 'arXiv preprint: Some Title' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should return false for non-arXiv item', () => {
+    const item = createMockItem({
+      title: 'Regular Paper',
+      publicationTitle: 'Nature',
+    });
+    expect(isArxivItem(item)).toBe(false);
+  });
+
+  it('should detect arXiv case-insensitively in publicationTitle', () => {
+    const item = createMockItem({ publicationTitle: 'ARXIV' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv case-insensitively in title', () => {
+    const item = createMockItem({ title: 'ARXIV Preprint: Some Title' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from URL with arXiv in query string', () => {
+    const item = createMockItem({ url: 'https://example.com?source=arXiv&id=123' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should detect arXiv from extra field with space separator', () => {
+    const item = createMockItem({ extra: 'arXiv 2301.12345' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should return false for item with empty fields', () => {
+    const item = createMockItem({
+      title: '',
+      publicationTitle: '',
+      url: '',
+      extra: ''
+    });
+    expect(isArxivItem(item)).toBe(false);
+  });
+
+  it('should detect arXiv from partial URL match', () => {
+    const item = createMockItem({ url: 'http://arxiv.org/pdf/2301.12345.pdf' });
+    expect(isArxivItem(item)).toBe(true);
+  });
+
+  it('should not match arXiv in unrelated context', () => {
+    // Title must not contain "arXiv" as a substring
+    const item = createMockItem({
+      title: 'A Study in Physics',  // Changed from "Not about arXiv" which contains "arXiv"
+      publicationTitle: 'Journal of Important Research',
+      extra: 'Some other info'
+    });
+    expect(isArxivItem(item)).toBe(false);
+  });
+});

--- a/tests/unit/zotadata/file-operations.test.ts
+++ b/tests/unit/zotadata/file-operations.test.ts
@@ -1,0 +1,679 @@
+// tests/unit/zotadata/file-operations.test.ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem, createMockAttachment, resetMockCounters } from '../../__mocks__/zotero-items';
+import { createMockHTTP, registerFixture, clearFixtures } from '../../__mocks__/zotero-http';
+import { unpaywallFixtures } from '../../__mocks__/fixtures/unpaywall';
+import { coreFixtures } from '../../__mocks__/fixtures/core';
+
+describe('File Operations', () => {
+  let mockHTTP: ReturnType<typeof createMockHTTP>;
+
+  beforeEach(() => {
+    clearCache();
+    clearFixtures();
+    resetMockCounters();
+    mockHTTP = createMockHTTP();
+    (globalThis as any).Zotero = {
+      HTTP: mockHTTP,
+      HTTP_request: mockHTTP.request,
+      Items: {
+        get: vi.fn(),
+      },
+      Attachments: {
+        LINK_MODE_IMPORTED_FILE: 0,
+        LINK_MODE_IMPORTED_URL: 1,
+        LINK_MODE_LINKED_FILE: 2,
+        LINK_MODE_LINKED_URL: 3,
+      },
+      ItemTypes: {
+        getName: vi.fn((typeId: number) => {
+          if (typeId === 1) return 'journalArticle';
+          if (typeId === 2) return 'book';
+          return 'journalArticle';
+        }),
+      },
+      Utilities: {
+        cleanDOI: (d: string) => d ? d.trim().toLowerCase() : d,
+        cleanISBN: (i: string) => i ? i.replace(/[-\s]/g, '') : i,
+      },
+      Prefs: {
+        get: vi.fn(() => 'test@example.com'),
+        set: vi.fn(),
+        clear: vi.fn(),
+      },
+      getMainWindow: vi.fn(() => ({
+        prompt: vi.fn(() => 'test@example.com'),
+        alert: vi.fn(),
+      })),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearFixtures();
+  });
+
+  describe('itemHasPDF', () => {
+    let itemHasPDF: (item: any) => Promise<boolean>;
+
+    beforeEach(() => {
+      itemHasPDF = createZotadataMethod('itemHasPDF');
+    });
+
+    it('should return true when item has valid PDF attachment', async () => {
+      const mockAttachment = {
+        id: 100,
+        isPDFAttachment: vi.fn(() => true),
+        getFile: vi.fn(() => ({ exists: () => true })),
+      };
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => [100]);
+      (Zotero.Items.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAttachment);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(true);
+      expect(item.getAttachments).toHaveBeenCalled();
+      expect(mockAttachment.isPDFAttachment).toHaveBeenCalled();
+    });
+
+    it('should return false when item has non-PDF attachment', async () => {
+      const mockAttachment = {
+        id: 100,
+        isPDFAttachment: vi.fn(() => false),
+        getFile: vi.fn(() => ({ exists: () => true })),
+      };
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => [100]);
+      (Zotero.Items.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAttachment);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when PDF file does not exist', async () => {
+      const mockAttachment = {
+        id: 100,
+        isPDFAttachment: vi.fn(() => true),
+        getFile: vi.fn(() => ({ exists: () => false })),
+      };
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => [100]);
+      (Zotero.Items.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAttachment);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when getFile throws error', async () => {
+      const mockAttachment = {
+        id: 100,
+        isPDFAttachment: vi.fn(() => true),
+        getFile: vi.fn(() => {
+          throw new Error('File not found');
+        }),
+      };
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => [100]);
+      (Zotero.Items.get as ReturnType<typeof vi.fn>).mockReturnValue(mockAttachment);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when item has no attachments', async () => {
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => []);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should check multiple attachments and find PDF', async () => {
+      const mockNonPDF = {
+        id: 100,
+        isPDFAttachment: vi.fn(() => false),
+        getFile: vi.fn(() => ({ exists: () => true })),
+      };
+      const mockPDF = {
+        id: 101,
+        isPDFAttachment: vi.fn(() => true),
+        getFile: vi.fn(() => ({ exists: () => true })),
+      };
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.getAttachments = vi.fn(() => [100, 101]);
+      (Zotero.Items.get as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(mockNonPDF)
+        .mockReturnValueOnce(mockPDF);
+
+      const result = await itemHasPDF(item);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('verifyStoredAttachment', () => {
+    let verifyStoredAttachment: (attachment: any) => boolean;
+
+    beforeEach(() => {
+      verifyStoredAttachment = createZotadataMethod('verifyStoredAttachment');
+    });
+
+    it('should return true for stored file with existing file', () => {
+      const attachment = createMockAttachment({
+        linkMode: 0, // LINK_MODE_IMPORTED_FILE
+        filePath: '/path/to/file.pdf',
+        fileExists: true,
+      });
+      attachment.getField = vi.fn(() => 'Test PDF');
+
+      const result = verifyStoredAttachment(attachment);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for imported URL attachment', () => {
+      const attachment = createMockAttachment({
+        linkMode: 1, // LINK_MODE_IMPORTED_URL
+        filePath: '/path/to/file.pdf',
+        fileExists: true,
+      });
+      attachment.getField = vi.fn(() => 'Test PDF');
+
+      const result = verifyStoredAttachment(attachment);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for linked file (not stored)', () => {
+      const attachment = createMockAttachment({
+        linkMode: 2, // LINK_MODE_LINKED_FILE
+        filePath: '/path/to/file.pdf',
+        fileExists: true,
+      });
+      attachment.getField = vi.fn(() => 'Test PDF');
+
+      const result = verifyStoredAttachment(attachment);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for URL link (not stored)', () => {
+      const attachment = createMockAttachment({
+        linkMode: 3, // LINK_MODE_LINKED_URL
+        filePath: null,
+        fileExists: false,
+      });
+      attachment.getField = vi.fn(() => 'Test URL');
+
+      const result = verifyStoredAttachment(attachment);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when file does not exist', () => {
+      const attachment = createMockAttachment({
+        linkMode: 0, // LINK_MODE_IMPORTED_FILE
+        filePath: '/path/to/file.pdf',
+        fileExists: false,
+      });
+      attachment.getField = vi.fn(() => 'Test PDF');
+
+      const result = verifyStoredAttachment(attachment);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for null attachment', () => {
+      const result = verifyStoredAttachment(null);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for undefined attachment', () => {
+      const result = verifyStoredAttachment(undefined);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('findUnpaywallPDF', () => {
+    let findUnpaywallPDF: (doi: string) => Promise<string | null>;
+
+    beforeEach(() => {
+      findUnpaywallPDF = createZotadataMethod('findUnpaywallPDF', {
+        getConfiguredEmail: () => 'test@example.com',
+      });
+    });
+
+    it('should return PDF URL when open access PDF found', async () => {
+      registerFixture('api.unpaywall.org', unpaywallFixtures.openAccessPDF);
+
+      const result = await findUnpaywallPDF('10.1000/test.doi');
+
+      expect(result).toBe('https://example.com/paper.pdf');
+    });
+
+    it('should return null when no open access available', async () => {
+      registerFixture('api.unpaywall.org', unpaywallFixtures.noOpenAccess);
+
+      const result = await findUnpaywallPDF('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when no PDF URL in response', async () => {
+      registerFixture('api.unpaywall.org', unpaywallFixtures.noPDFURL);
+
+      const result = await findUnpaywallPDF('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when email is not configured', async () => {
+      findUnpaywallPDF = createZotadataMethod('findUnpaywallPDF', {
+        getConfiguredEmail: () => null,
+      });
+
+      const result = await findUnpaywallPDF('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      registerFixture('api.unpaywall.org', unpaywallFixtures.serverError);
+
+      const result = await findUnpaywallPDF('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should handle 404 not found gracefully', async () => {
+      registerFixture('api.unpaywall.org', unpaywallFixtures.notFound);
+
+      const result = await findUnpaywallPDF('10.1000/nonexistent.doi');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('findCorePDFByDOI', () => {
+    let findCorePDFByDOI: (doi: string) => Promise<string | null>;
+
+    beforeEach(() => {
+      findCorePDFByDOI = createZotadataMethod('findCorePDFByDOI');
+    });
+
+    it('should return PDF URL when found with downloadUrl', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.pdfFound);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe('https://core.ac.uk/download/pdf/12345.pdf');
+    });
+
+    it('should return first valid PDF URL from multiple results', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.multipleResults);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe('https://core.ac.uk/download/pdf/22222.pdf');
+    });
+
+    it('should return null when no results found', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.noResults);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when downloadUrl is null', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.noDownloadUrl);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when URL is not a PDF', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.nonPdfUrl);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      registerFixture('api.core.ac.uk', coreFixtures.serverError);
+
+      const result = await findCorePDFByDOI('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('findArxivPDF', () => {
+    it('should return arXiv PDF URL when arXiv ID is found', async () => {
+      const mockExtractArxivId = vi.fn(() => '2301.12345');
+      const findArxivPDF = createZotadataMethod('findArxivPDF', {
+        extractArxivId: mockExtractArxivId,
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchArxiv: vi.fn().mockResolvedValue(null),
+      });
+
+      const item = createMockItem({
+        title: 'Test arXiv Paper',
+        extra: 'arXiv:2301.12345',
+      });
+
+      const result = await findArxivPDF(item);
+
+      expect(result).toBe('http://arxiv.org/pdf/2301.12345.pdf');
+    });
+
+    it('should search arXiv by title when no arXiv ID', async () => {
+      const mockExtractArxivId = vi.fn(() => null);
+      const mockSearchArxiv = vi.fn().mockResolvedValue('2301.99999');
+      const findArxivPDF = createZotadataMethod('findArxivPDF', {
+        extractArxivId: mockExtractArxivId,
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchArxiv: mockSearchArxiv,
+      });
+
+      const item = createMockItem({ title: 'Test Paper' });
+
+      const result = await findArxivPDF(item);
+
+      expect(result).toBe('http://arxiv.org/pdf/2301.99999.pdf');
+      expect(mockSearchArxiv).toHaveBeenCalledWith('Test Paper');
+    });
+
+    it('should return null when no arXiv ID and search fails', async () => {
+      const mockExtractArxivId = vi.fn(() => null);
+      const mockSearchArxiv = vi.fn().mockResolvedValue(null);
+      const findArxivPDF = createZotadataMethod('findArxivPDF', {
+        extractArxivId: mockExtractArxivId,
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchArxiv: mockSearchArxiv,
+      });
+
+      const item = createMockItem({ title: 'Test Paper' });
+
+      const result = await findArxivPDF(item);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when item has no title', async () => {
+      const mockExtractArxivId = vi.fn(() => null);
+      const findArxivPDF = createZotadataMethod('findArxivPDF', {
+        extractArxivId: mockExtractArxivId,
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchArxiv: vi.fn().mockResolvedValue(null),
+      });
+
+      const item = createMockItem({ title: '' });
+      item.getField = vi.fn((field: string) => field === 'title' ? '' : '');
+
+      const result = await findArxivPDF(item);
+
+      expect(result).toBe(null);
+    });
+
+    it('should handle errors gracefully', async () => {
+      const mockExtractArxivId = vi.fn(() => {
+        throw new Error('Extraction error');
+      });
+      const findArxivPDF = createZotadataMethod('findArxivPDF', {
+        extractArxivId: mockExtractArxivId,
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+        searchArxiv: vi.fn().mockResolvedValue(null),
+      });
+
+      const item = createMockItem({ title: 'Test Paper' });
+
+      const result = await findArxivPDF(item);
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('findPublishedPDF', () => {
+    it('should return URL from Unpaywall when found', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockResolvedValue('https://unpaywall.com/paper.pdf');
+      const mockFindCorePDFByDOI = vi.fn().mockResolvedValue(null);
+      const findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: mockFindCorePDFByDOI,
+      });
+
+      const result = await findPublishedPDF('10.1000/test.doi');
+
+      expect(result).toBe('https://unpaywall.com/paper.pdf');
+      expect(mockFindUnpaywallPDF).toHaveBeenCalledWith('10.1000/test.doi');
+      expect(mockFindCorePDFByDOI).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to CORE when Unpaywall returns null', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockResolvedValue(null);
+      const mockFindCorePDFByDOI = vi.fn().mockResolvedValue('https://core.ac.uk/download/pdf/123.pdf');
+      const findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: mockFindCorePDFByDOI,
+      });
+
+      const result = await findPublishedPDF('10.1000/test.doi');
+
+      expect(result).toBe('https://core.ac.uk/download/pdf/123.pdf');
+      expect(mockFindUnpaywallPDF).toHaveBeenCalledWith('10.1000/test.doi');
+      expect(mockFindCorePDFByDOI).toHaveBeenCalledWith('10.1000/test.doi');
+    });
+
+    it('should return null when both Unpaywall and CORE return null', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockResolvedValue(null);
+      const mockFindCorePDFByDOI = vi.fn().mockResolvedValue(null);
+      const findPublishedPDF = createZotadataMethod('findPublishedPDF', {
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: mockFindCorePDFByDOI,
+      });
+
+      const result = await findPublishedPDF('10.1000/test.doi');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('findFileForItem', () => {
+    it('should find PDF via Unpaywall for article with DOI', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockResolvedValue('https://example.com/paper.pdf');
+      const mockFindCorePDFByDOI = vi.fn().mockResolvedValue(null);
+      const mockFindArxivPDF = vi.fn().mockResolvedValue(null);
+
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+        extractISBN: vi.fn().mockReturnValue(null),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: mockFindCorePDFByDOI,
+        findArxivPDF: mockFindArxivPDF,
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: vi.fn().mockResolvedValue(null),
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({
+        title: 'Test Paper',
+        DOI: '10.1000/test.doi',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: 'https://example.com/paper.pdf',
+        source: 'Unpaywall',
+      });
+    });
+
+    it('should find PDF via arXiv for article without DOI', async () => {
+      const mockFindArxivPDF = vi.fn().mockResolvedValue('http://arxiv.org/pdf/2301.12345.pdf');
+
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue(null),
+        extractISBN: vi.fn().mockReturnValue(null),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: vi.fn().mockResolvedValue(null),
+        findCorePDFByDOI: vi.fn().mockResolvedValue(null),
+        findArxivPDF: mockFindArxivPDF,
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: vi.fn().mockResolvedValue(null),
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({ title: 'Test arXiv Paper' });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: 'http://arxiv.org/pdf/2301.12345.pdf',
+        source: 'arXiv',
+      });
+    });
+
+    it('should find PDF via CORE when Unpaywall fails', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockResolvedValue(null);
+      const mockFindCorePDFByDOI = vi.fn().mockResolvedValue('https://core.ac.uk/download/pdf/123.pdf');
+
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+        extractISBN: vi.fn().mockReturnValue(null),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: mockFindCorePDFByDOI,
+        findArxivPDF: vi.fn().mockResolvedValue(null),
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: vi.fn().mockResolvedValue(null),
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({
+        title: 'Test Paper',
+        DOI: '10.1000/test.doi',
+      });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: 'https://core.ac.uk/download/pdf/123.pdf',
+        source: 'CORE',
+      });
+    });
+
+    it('should return null when no sources find PDF', async () => {
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+        extractISBN: vi.fn().mockReturnValue(null),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: vi.fn().mockResolvedValue(null),
+        findCorePDFByDOI: vi.fn().mockResolvedValue(null),
+        findArxivPDF: vi.fn().mockResolvedValue(null),
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: vi.fn().mockResolvedValue(null),
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({ title: 'Unknown Paper' });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: null,
+        source: null,
+      });
+    });
+
+    it('should use book-specific strategy for books', async () => {
+      const mockFindInternetArchiveBook = vi.fn().mockResolvedValue('https://archive.org/book.pdf');
+
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue(null),
+        extractISBN: vi.fn().mockReturnValue('978-0-123456-78-9'),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: vi.fn().mockResolvedValue(null),
+        findCorePDFByDOI: vi.fn().mockResolvedValue(null),
+        findArxivPDF: vi.fn().mockResolvedValue(null),
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: mockFindInternetArchiveBook,
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({ title: 'Test Book' });
+      item.itemTypeID = 2; // book
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: 'https://archive.org/book.pdf',
+        source: 'Internet Archive',
+      });
+    });
+
+    it('should handle errors gracefully', async () => {
+      const mockFindUnpaywallPDF = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const findFileForItem = createZotadataMethod('findFileForItem', {
+        extractDOI: vi.fn().mockReturnValue('10.1000/test.doi'),
+        extractISBN: vi.fn().mockReturnValue(null),
+        extractArxivId: vi.fn().mockReturnValue(null),
+        findUnpaywallPDF: mockFindUnpaywallPDF,
+        findCorePDFByDOI: vi.fn().mockResolvedValue(null),
+        findArxivPDF: vi.fn().mockResolvedValue(null),
+        findLibGenPDF: vi.fn().mockResolvedValue(null),
+        tryCustomResolvers: vi.fn().mockResolvedValue({ url: null, source: null }),
+        findInternetArchiveBook: vi.fn().mockResolvedValue(null),
+        findOpenLibraryPDF: vi.fn().mockResolvedValue(null),
+        findGoogleBooksFullText: vi.fn().mockResolvedValue(null),
+        titleSimilarity: createZotadataMethod('titleSimilarity'),
+      });
+
+      const item = createMockItem({ title: 'Test Paper' });
+      item.itemTypeID = 1; // journalArticle
+
+      const result = await findFileForItem(item);
+
+      expect(result).toEqual({
+        url: null,
+        source: null,
+      });
+    });
+  });
+});

--- a/tests/unit/zotadata/isbn-convert.test.ts
+++ b/tests/unit/zotadata/isbn-convert.test.ts
@@ -1,0 +1,71 @@
+// tests/unit/zotadata/isbn-convert.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod } from '../../helpers/extract-function';
+
+describe('convertISBN10to13', () => {
+  let convertISBN10to13: (isbn: string) => string | null;
+
+  beforeEach(() => {
+    convertISBN10to13 = createZotadataMethod('convertISBN10to13');
+  });
+
+  it('should convert valid ISBN-10 to ISBN-13', () => {
+    // 0-306-40615-2 -> 978-0-306-40615-7
+    const result = convertISBN10to13('0306406152');
+    expect(result).toBe('9780306406157');
+  });
+
+  it('should handle ISBN-10 with X check digit', () => {
+    // 0-201-63361-X -> 978-0-201-63361-0
+    const result = convertISBN10to13('020163361X');
+    expect(result).toBe('9780201633610');
+  });
+
+  it('should return null for invalid length', () => {
+    expect(convertISBN10to13('12345')).toBe(null);
+    expect(convertISBN10to13('12345678901234')).toBe(null);
+  });
+});
+
+describe('convertISBN13to10', () => {
+  let convertISBN13to10: (isbn: string) => string | null;
+
+  beforeEach(() => {
+    convertISBN13to10 = createZotadataMethod('convertISBN13to10');
+  });
+
+  it('should convert valid 978-prefix ISBN-13 to ISBN-10', () => {
+    // 978-0-306-40615-7 -> 0-306-40615-2
+    const result = convertISBN13to10('9780306406157');
+    expect(result).toBe('0306406152');
+  });
+
+  it('should return null for non-978 prefix', () => {
+    // 979 prefix cannot be converted to ISBN-10
+    expect(convertISBN13to10('9791234567890')).toBe(null);
+  });
+
+  it('should return null for invalid length', () => {
+    expect(convertISBN13to10('12345')).toBe(null);
+  });
+});
+
+describe('formatISBNWithHyphens', () => {
+  let formatISBNWithHyphens: (isbn: string) => string;
+
+  beforeEach(() => {
+    formatISBNWithHyphens = createZotadataMethod('formatISBNWithHyphens');
+  });
+
+  it('should format ISBN-10 with hyphens', () => {
+    expect(formatISBNWithHyphens('0306406152')).toBe('0-30640-615-2');
+  });
+
+  it('should format ISBN-13 with hyphens', () => {
+    expect(formatISBNWithHyphens('9780306406157')).toBe('978-0-30640-615-7');
+  });
+
+  it('should return original for invalid input', () => {
+    expect(formatISBNWithHyphens('invalid')).toBe('invalid');
+  });
+});

--- a/tests/unit/zotadata/metadata.test.ts
+++ b/tests/unit/zotadata/metadata.test.ts
@@ -1,0 +1,917 @@
+// tests/unit/zotadata/metadata.test.ts
+// Tests for metadata pipeline functions in zotadata.js
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+import { createMockItem } from '../../__mocks__/zotero-items';
+import { setupTranslateMock } from '../../__mocks__/zotero-translate';
+
+describe('Metadata Pipeline Functions', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchDOIBasedMetadata', () => {
+    let fetchDOIBasedMetadata: (item: any) => Promise<any>;
+    let mockExtractDOI: ReturnType<typeof vi.fn>;
+    let mockDiscoverDOI: ReturnType<typeof vi.fn>;
+    let mockFetchDOIMetadataViaTranslator: ReturnType<typeof vi.fn>;
+    let mockFetchCrossRefMetadata: ReturnType<typeof vi.fn>;
+    let mockUpdateItemWithMetadata: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockExtractDOI = vi.fn().mockReturnValue(null);
+      mockDiscoverDOI = vi.fn().mockResolvedValue(null);
+      mockFetchDOIMetadataViaTranslator = vi.fn().mockResolvedValue(false);
+      mockFetchCrossRefMetadata = vi.fn().mockResolvedValue(null);
+      mockUpdateItemWithMetadata = vi.fn().mockResolvedValue(undefined);
+
+      fetchDOIBasedMetadata = createZotadataMethod('fetchDOIBasedMetadata', {
+        extractDOI: mockExtractDOI,
+        discoverDOI: mockDiscoverDOI,
+        fetchDOIMetadataViaTranslator: mockFetchDOIMetadataViaTranslator,
+        fetchCrossRefMetadata: mockFetchCrossRefMetadata,
+        updateItemWithMetadata: mockUpdateItemWithMetadata,
+      });
+    });
+
+    it('should use existing DOI when present', async () => {
+      mockExtractDOI.mockReturnValue('10.1000/existing.doi');
+      mockFetchDOIMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem({ DOI: '10.1000/existing.doi' });
+      const result = await fetchDOIBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockExtractDOI).toHaveBeenCalledWith(item);
+      expect(mockDiscoverDOI).not.toHaveBeenCalled();
+      expect(mockFetchDOIMetadataViaTranslator).toHaveBeenCalledWith('10.1000/existing.doi', item);
+    });
+
+    it('should discover DOI when not present', async () => {
+      mockExtractDOI.mockReturnValue(null);
+      mockDiscoverDOI.mockResolvedValue('10.1000/discovered.doi');
+      mockFetchDOIMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem({ title: 'Test Paper' });
+      const result = await fetchDOIBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockDiscoverDOI).toHaveBeenCalledWith(item);
+      expect(item.setField).toHaveBeenCalledWith('DOI', '10.1000/discovered.doi');
+    });
+
+    it('should fallback to CrossRef API when translator fails', async () => {
+      mockExtractDOI.mockReturnValue('10.1000/test.doi');
+      mockFetchDOIMetadataViaTranslator.mockResolvedValue(false);
+      mockFetchCrossRefMetadata.mockResolvedValue({
+        DOI: '10.1000/test.doi',
+        title: ['Test Paper'],
+      });
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockFetchCrossRefMetadata).toHaveBeenCalledWith('10.1000/test.doi');
+      expect(mockUpdateItemWithMetadata).toHaveBeenCalledWith(item, {
+        DOI: '10.1000/test.doi',
+        title: ['Test Paper'],
+      });
+    });
+
+    it('should add CrossRef Failed tag when both methods fail', async () => {
+      mockExtractDOI.mockReturnValue('10.1000/test.doi');
+      mockFetchDOIMetadataViaTranslator.mockResolvedValue(false);
+      mockFetchCrossRefMetadata.mockResolvedValue(null);
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIBasedMetadata(item);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('CrossRef API failed');
+      expect(item.addTag).toHaveBeenCalledWith('CrossRef Failed', 1);
+    });
+
+    it('should add No DOI Found tag when no DOI discovered', async () => {
+      mockExtractDOI.mockReturnValue(null);
+      mockDiscoverDOI.mockResolvedValue(null);
+
+      const item = createMockItem({ title: 'Unknown Paper' });
+      const result = await fetchDOIBasedMetadata(item);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No DOI found');
+      expect(item.addTag).toHaveBeenCalledWith('No DOI Found', 1);
+    });
+
+    it('should add DOI Added tag when DOI is discovered', async () => {
+      mockExtractDOI.mockReturnValue(null);
+      mockDiscoverDOI.mockResolvedValue('10.1000/discovered.doi');
+      mockFetchDOIMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem({ title: 'Test Paper' });
+      await fetchDOIBasedMetadata(item);
+
+      expect(item.addTag).toHaveBeenCalledWith('DOI Added', 1);
+    });
+  });
+
+  describe('fetchISBNBasedMetadata', () => {
+    let fetchISBNBasedMetadata: (item: any) => Promise<any>;
+    let mockExtractISBN: ReturnType<typeof vi.fn>;
+    let mockDiscoverISBN: ReturnType<typeof vi.fn>;
+    let mockFetchBookMetadata: ReturnType<typeof vi.fn>;
+    let mockUpdateItemWithBookMetadata: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockExtractISBN = vi.fn().mockReturnValue(null);
+      mockDiscoverISBN = vi.fn().mockResolvedValue(null);
+      mockFetchBookMetadata = vi.fn().mockResolvedValue(null);
+      mockUpdateItemWithBookMetadata = vi.fn().mockResolvedValue(undefined);
+
+      fetchISBNBasedMetadata = createZotadataMethod('fetchISBNBasedMetadata', {
+        extractISBN: mockExtractISBN,
+        discoverISBN: mockDiscoverISBN,
+        fetchBookMetadata: mockFetchBookMetadata,
+        updateItemWithBookMetadata: mockUpdateItemWithBookMetadata,
+      });
+    });
+
+    it('should use existing ISBN when present', async () => {
+      mockExtractISBN.mockReturnValue('9780123456789');
+      mockFetchBookMetadata.mockResolvedValue({
+        title: 'Test Book',
+        authors: [{ name: 'John Smith' }],
+      });
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockExtractISBN).toHaveBeenCalledWith(item);
+      expect(mockDiscoverISBN).not.toHaveBeenCalled();
+      expect(mockFetchBookMetadata).toHaveBeenCalledWith('9780123456789', item);
+    });
+
+    it('should discover ISBN when not present', async () => {
+      mockExtractISBN.mockReturnValue(null);
+      mockDiscoverISBN.mockResolvedValue('9780123456789');
+      mockFetchBookMetadata.mockResolvedValue({
+        title: 'Test Book',
+        authors: [{ name: 'John Smith' }],
+      });
+
+      const item = createMockItem({ title: 'Test Book' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockDiscoverISBN).toHaveBeenCalledWith(item);
+      expect(item.setField).toHaveBeenCalledWith('ISBN', '9780123456789');
+    });
+
+    it('should handle translator success format', async () => {
+      mockExtractISBN.mockReturnValue('9780123456789');
+      mockFetchBookMetadata.mockResolvedValue({
+        source: 'Zotero Translator',
+        success: true,
+      });
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(item.addTag).toHaveBeenCalledWith('Metadata Updated', 1);
+      expect(item.addTag).toHaveBeenCalledWith('Via Zotero Translator', 1);
+    });
+
+    it('should handle traditional API metadata format', async () => {
+      mockExtractISBN.mockReturnValue('9780123456789');
+      mockFetchBookMetadata.mockResolvedValue({
+        title: 'Test Book',
+        authors: [{ name: 'John Smith' }],
+        publishers: ['Test Publisher'],
+      });
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(true);
+      expect(mockUpdateItemWithBookMetadata).toHaveBeenCalledWith(item, {
+        title: 'Test Book',
+        authors: [{ name: 'John Smith' }],
+        publishers: ['Test Publisher'],
+      });
+    });
+
+    it('should add Book API Failed tag when metadata fetch fails', async () => {
+      mockExtractISBN.mockReturnValue('9780123456789');
+      mockFetchBookMetadata.mockResolvedValue(null);
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Book API failed');
+      expect(item.addTag).toHaveBeenCalledWith('Book API Failed', 1);
+    });
+
+    it('should add No ISBN Found tag when no ISBN discovered', async () => {
+      mockExtractISBN.mockReturnValue(null);
+      mockDiscoverISBN.mockResolvedValue(null);
+
+      const item = createMockItem({ title: 'Unknown Book' });
+      const result = await fetchISBNBasedMetadata(item);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No ISBN found');
+      expect(item.addTag).toHaveBeenCalledWith('No ISBN Found', 1);
+    });
+  });
+
+  describe('updateItemWithMetadata', () => {
+    let updateItemWithMetadata: (item: any, metadata: any) => Promise<void>;
+
+    beforeEach(() => {
+      (globalThis as any).Zotero = {
+        CreatorTypes: {
+          getPrimaryIDForType: () => 1,
+        },
+      };
+      updateItemWithMetadata = createZotadataMethod('updateItemWithMetadata');
+    });
+
+    it('should update title when empty or short', async () => {
+      const item = createMockItem({ title: '' });
+      const metadata = {
+        title: ['New Title From Metadata'],
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('title', 'New Title From Metadata');
+    });
+
+    it('should not update title when already long enough', async () => {
+      const item = createMockItem({ title: 'This is a long existing title' });
+      const metadata = {
+        title: ['New Title From Metadata'],
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      // Title should not be updated since current title is >= 10 chars
+      expect(item.setField).not.toHaveBeenCalledWith('title', expect.anything());
+    });
+
+    it('should update authors when item has no creators', async () => {
+      const item = createMockItem({ creators: [] });
+      item.numCreators = () => 0;
+      item.setCreator = vi.fn();
+
+      const metadata = {
+        author: [
+          { given: 'John', family: 'Smith' },
+          { given: 'Jane', family: 'Doe' },
+        ],
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setCreator).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not update authors when item already has creators', async () => {
+      const item = createMockItem({ creators: [{ lastName: 'Existing' }] });
+      item.setCreator = vi.fn();
+
+      const metadata = {
+        author: [{ given: 'John', family: 'Smith' }],
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setCreator).not.toHaveBeenCalled();
+    });
+
+    it('should update volume/issue/pages', async () => {
+      const item = createMockItem();
+      const metadata = {
+        volume: '10',
+        issue: '2',
+        page: '123-145',
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('volume', '10');
+      expect(item.setField).toHaveBeenCalledWith('issue', '2');
+      expect(item.setField).toHaveBeenCalledWith('pages', '123-145');
+    });
+
+    it('should update URL when not present', async () => {
+      const item = createMockItem({ url: '' });
+      const metadata = {
+        URL: 'https://doi.org/10.1000/test.doi',
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('url', 'https://doi.org/10.1000/test.doi');
+    });
+
+    it('should not update URL when already present', async () => {
+      const item = createMockItem({ url: 'https://existing.url' });
+      const metadata = {
+        URL: 'https://doi.org/10.1000/test.doi',
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).not.toHaveBeenCalledWith('url', expect.anything());
+    });
+
+    it('should update publication title from container-title', async () => {
+      const item = createMockItem();
+      const metadata = {
+        'container-title': ['Test Journal'],
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('publicationTitle', 'Test Journal');
+    });
+
+    it('should update date from published date-parts', async () => {
+      const item = createMockItem();
+      const metadata = {
+        published: {
+          'date-parts': [[2023, 5, 15]],
+        },
+      };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('date', '2023');
+    });
+
+    it('should save item after updates', async () => {
+      const item = createMockItem();
+      const metadata = { title: ['Test'] };
+
+      await updateItemWithMetadata(item, metadata);
+
+      expect(item.saveTx).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateItemWithBookMetadata', () => {
+    let updateItemWithBookMetadata: (item: any, metadata: any) => Promise<void>;
+
+    beforeEach(() => {
+      (globalThis as any).Zotero = {
+        CreatorTypes: {
+          getPrimaryIDForType: () => 1,
+        },
+      };
+      updateItemWithBookMetadata = createZotadataMethod('updateItemWithBookMetadata');
+    });
+
+    it('should update title when empty or short', async () => {
+      const item = createMockItem({ title: '' });
+      const metadata = {
+        title: 'New Book Title',
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('title', 'New Book Title');
+    });
+
+    it('should update authors from OpenLibrary format', async () => {
+      const item = createMockItem({ creators: [] });
+      item.numCreators = () => 0;
+      item.setCreator = vi.fn();
+
+      const metadata = {
+        authors: [{ name: 'John Smith' }, { name: 'Jane Doe' }],
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setCreator).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle authors as string array', async () => {
+      const item = createMockItem({ creators: [] });
+      item.numCreators = () => 0;
+      item.setCreator = vi.fn();
+
+      const metadata = {
+        authors: ['John Smith', 'Jane Doe'],
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setCreator).toHaveBeenCalledTimes(2);
+    });
+
+    it('should update publisher', async () => {
+      const item = createMockItem();
+      const metadata = {
+        publishers: ['Test Publisher'],
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('publisher', 'Test Publisher');
+    });
+
+    it('should update publication date', async () => {
+      const item = createMockItem();
+      const metadata = {
+        publish_date: '2023',
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('date', '2023');
+    });
+
+    it('should update number of pages', async () => {
+      const item = createMockItem();
+      const metadata = {
+        number_of_pages: 350,
+      };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.setField).toHaveBeenCalledWith('numPages', '350');
+    });
+
+    it('should save item after updates', async () => {
+      const item = createMockItem();
+      const metadata = { title: 'Test Book' };
+
+      await updateItemWithBookMetadata(item, metadata);
+
+      expect(item.saveTx).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchBookMetadataViaTranslator', () => {
+    let fetchBookMetadataViaTranslator: (isbn: string, item: any) => Promise<boolean>;
+
+    beforeEach(() => {
+      fetchBookMetadataViaTranslator = createZotadataMethod('fetchBookMetadataViaTranslator');
+    });
+
+    it('should return true when translator finds metadata', async () => {
+      const mockNewItem = {
+        getField: vi.fn((field: string) => {
+          if (field === 'title') return 'Book Title from Translator';
+          return '';
+        }),
+        getCreators: vi.fn(() => [{ firstName: 'John', lastName: 'Smith' }]),
+        setCreators: vi.fn(),
+        deleted: false,
+        saveTx: vi.fn().mockResolvedValue(undefined),
+      };
+
+      // Create a mock class constructor
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([mockNewItem]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'book',
+        },
+      };
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+      expect(result).toBe(true);
+      expect(MockTranslateSearch).toHaveBeenCalled();
+    });
+
+    it('should return false when no translators available', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'book',
+        },
+      };
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when translation returns no items', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'book',
+        },
+      };
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should apply fields from translated item', async () => {
+      const mockNewItem = {
+        getField: vi.fn((field: string) => {
+          switch (field) {
+            case 'title': return 'Translated Title';
+            case 'publisher': return 'Test Publisher';
+            case 'date': return '2023';
+            default: return '';
+          }
+        }),
+        getCreators: vi.fn(() => []),
+        setCreators: vi.fn(),
+        deleted: false,
+        saveTx: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([mockNewItem]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'book',
+        },
+      };
+
+      const item = createMockItem({ ISBN: '9780123456789', title: '' });
+      await fetchBookMetadataViaTranslator('9780123456789', item);
+
+      expect(item.setField).toHaveBeenCalledWith('title', 'Translated Title');
+      expect(item.setField).toHaveBeenCalledWith('publisher', 'Test Publisher');
+      expect(item.setField).toHaveBeenCalledWith('date', '2023');
+    });
+
+    it('should handle errors gracefully', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockRejectedValue(new Error('Translator error')),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'book',
+        },
+      };
+
+      const item = createMockItem({ ISBN: '9780123456789' });
+      const result = await fetchBookMetadataViaTranslator('9780123456789', item);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('fetchDOIMetadataViaTranslator', () => {
+    let fetchDOIMetadataViaTranslator: (doi: string, item: any) => Promise<boolean>;
+
+    beforeEach(() => {
+      fetchDOIMetadataViaTranslator = createZotadataMethod('fetchDOIMetadataViaTranslator');
+    });
+
+    it('should return true when translator finds metadata', async () => {
+      const mockNewItem = {
+        getField: vi.fn((field: string) => {
+          if (field === 'title') return 'Article Title from Translator';
+          return '';
+        }),
+        getCreators: vi.fn(() => [{ firstName: 'John', lastName: 'Smith' }]),
+        setCreators: vi.fn(),
+        deleted: false,
+        saveTx: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([mockNewItem]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(result).toBe(true);
+      expect(MockTranslateSearch).toHaveBeenCalled();
+    });
+
+    it('should return false when no translators available', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when translation returns no items', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(result).toBe(false);
+    });
+
+    it('should apply fields from translated item', async () => {
+      const mockNewItem = {
+        getField: vi.fn((field: string) => {
+          switch (field) {
+            case 'title': return 'Translated Article';
+            case 'publicationTitle': return 'Test Journal';
+            case 'volume': return '10';
+            case 'issue': return '2';
+            case 'pages': return '123-145';
+            default: return '';
+          }
+        }),
+        getCreators: vi.fn(() => []),
+        deleted: false,
+        saveTx: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([mockNewItem]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '10.1000/test.doi', title: '' });
+      await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(item.setField).toHaveBeenCalledWith('title', 'Translated Article');
+      expect(item.setField).toHaveBeenCalledWith('publicationTitle', 'Test Journal');
+      expect(item.setField).toHaveBeenCalledWith('volume', '10');
+      expect(item.setField).toHaveBeenCalledWith('issue', '2');
+      expect(item.setField).toHaveBeenCalledWith('pages', '123-145');
+    });
+
+    it('should set DOI field if not present', async () => {
+      const mockNewItem = {
+        getField: vi.fn(() => ''),
+        getCreators: vi.fn(() => []),
+        deleted: false,
+        saveTx: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockResolvedValue([{ translatorID: 'test' }]),
+        setTranslator: vi.fn(),
+        translate: vi.fn().mockResolvedValue([mockNewItem]),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '' });
+      item.getField = vi.fn((field: string) => {
+        if (field === 'DOI') return '';
+        return '';
+      });
+
+      await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(item.setField).toHaveBeenCalledWith('DOI', '10.1000/test.doi');
+    });
+
+    it('should handle errors gracefully', async () => {
+      const MockTranslateSearch = vi.fn().mockImplementation(() => ({
+        setIdentifier: vi.fn(),
+        getTranslators: vi.fn().mockRejectedValue(new Error('Translator error')),
+      }));
+
+      (globalThis as any).Zotero = {
+        Translate: {
+          Search: MockTranslateSearch,
+        },
+        ItemTypes: {
+          getName: () => 'journalArticle',
+        },
+      };
+
+      const item = createMockItem({ DOI: '10.1000/test.doi' });
+      const result = await fetchDOIMetadataViaTranslator('10.1000/test.doi', item);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('tryAlternativeISBNFormats', () => {
+    let tryAlternativeISBNFormats: (originalISBN: string, item: any) => Promise<any>;
+    let mockFetchBookMetadataViaTranslator: ReturnType<typeof vi.fn>;
+    let mockFetchOpenLibraryMetadata: ReturnType<typeof vi.fn>;
+    let mockFetchGoogleBooksMetadata: ReturnType<typeof vi.fn>;
+    let mockConvertISBN10to13: ReturnType<typeof vi.fn>;
+    let mockConvertISBN13to10: ReturnType<typeof vi.fn>;
+    let mockFormatISBNWithHyphens: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetchBookMetadataViaTranslator = vi.fn().mockResolvedValue(false);
+      mockFetchOpenLibraryMetadata = vi.fn().mockResolvedValue(null);
+      mockFetchGoogleBooksMetadata = vi.fn().mockResolvedValue(null);
+      mockConvertISBN10to13 = vi.fn().mockReturnValue(null);
+      mockConvertISBN13to10 = vi.fn().mockReturnValue(null);
+      mockFormatISBNWithHyphens = vi.fn().mockImplementation((isbn: string) => isbn);
+
+      tryAlternativeISBNFormats = createZotadataMethod('tryAlternativeISBNFormats', {
+        fetchBookMetadataViaTranslator: mockFetchBookMetadataViaTranslator,
+        fetchOpenLibraryMetadata: mockFetchOpenLibraryMetadata,
+        fetchGoogleBooksMetadata: mockFetchGoogleBooksMetadata,
+        convertISBN10to13: mockConvertISBN10to13,
+        convertISBN13to10: mockConvertISBN13to10,
+        formatISBNWithHyphens: mockFormatISBNWithHyphens,
+      });
+    });
+
+    it('should try ISBN-10 to ISBN-13 conversion', async () => {
+      mockConvertISBN10to13.mockReturnValue('9780123456789');
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('0123456789', item);
+
+      expect(result).toEqual({ source: 'Zotero Translator', success: true });
+      expect(mockConvertISBN10to13).toHaveBeenCalledWith('0123456789');
+      expect(mockFetchBookMetadataViaTranslator).toHaveBeenCalledWith('9780123456789', item);
+    });
+
+    it('should try ISBN-13 to ISBN-10 conversion', async () => {
+      mockConvertISBN13to10.mockReturnValue('0123456789');
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('9780123456789', item);
+
+      expect(result).toEqual({ source: 'Zotero Translator', success: true });
+      expect(mockConvertISBN13to10).toHaveBeenCalledWith('9780123456789');
+      expect(mockFetchBookMetadataViaTranslator).toHaveBeenCalledWith('0123456789', item);
+    });
+
+    it('should try OpenLibrary when translator fails', async () => {
+      mockConvertISBN13to10.mockReturnValue('0123456789');
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(false);
+      mockFetchOpenLibraryMetadata.mockResolvedValue({ title: 'Found in OpenLibrary' });
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('9780123456789', item);
+
+      expect(result).toEqual({ title: 'Found in OpenLibrary' });
+      expect(mockFetchOpenLibraryMetadata).toHaveBeenCalled();
+    });
+
+    it('should try Google Books when OpenLibrary fails', async () => {
+      mockConvertISBN13to10.mockReturnValue('0123456789');
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(false);
+      mockFetchOpenLibraryMetadata.mockResolvedValue(null);
+      mockFetchGoogleBooksMetadata.mockResolvedValue({ title: 'Found in Google Books' });
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('9780123456789', item);
+
+      expect(result).toEqual({ title: 'Found in Google Books' });
+      expect(mockFetchGoogleBooksMetadata).toHaveBeenCalled();
+    });
+
+    it('should return null when all formats fail', async () => {
+      mockConvertISBN13to10.mockReturnValue('0123456789');
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(false);
+      mockFetchOpenLibraryMetadata.mockResolvedValue(null);
+      mockFetchGoogleBooksMetadata.mockResolvedValue(null);
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('9780123456789', item);
+
+      expect(result).toBe(null);
+    });
+
+    it('should handle ISBN with hyphens', async () => {
+      mockFetchBookMetadataViaTranslator.mockResolvedValue(true);
+
+      const item = createMockItem();
+      await tryAlternativeISBNFormats('978-0-123456-78-9', item);
+
+      // The function cleans ISBN by removing hyphens
+      expect(mockConvertISBN13to10).toHaveBeenCalledWith('9780123456789');
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockConvertISBN13to10.mockImplementation(() => {
+        throw new Error('Conversion error');
+      });
+
+      const item = createMockItem();
+      const result = await tryAlternativeISBNFormats('9780123456789', item);
+
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/tests/unit/zotadata/utils.test.ts
+++ b/tests/unit/zotadata/utils.test.ts
@@ -1,0 +1,249 @@
+// tests/unit/zotadata/utils.test.ts
+// Tests for utility functions in zotadata.js
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createZotadataMethod, clearCache } from '../../helpers/extract-function';
+
+describe('Utility Functions', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  describe('titleSimilarity', () => {
+    let titleSimilarity: (t1: string, t2: string) => number;
+
+    beforeEach(() => {
+      titleSimilarity = createZotadataMethod('titleSimilarity');
+    });
+
+    it('should return 1.0 for exact match', () => {
+      expect(titleSimilarity('Test Title', 'Test Title')).toBe(1.0);
+    });
+
+    it('should be case insensitive', () => {
+      expect(titleSimilarity('Test Title', 'TEST TITLE')).toBe(1.0);
+    });
+
+    it('should ignore stop words', () => {
+      const result = titleSimilarity('The Test of the Title', 'Test Title');
+      expect(result).toBeGreaterThan(0.8);
+    });
+
+    it('should handle punctuation (strips non-word chars)', () => {
+      // The implementation strips punctuation without adding spaces
+      // "Test-Title: A Study" -> "TestTitle A Study" (hyphen/colon removed)
+      // "Test Title A Study" -> "Test Title A Study"
+      // Word overlap: "A", "Study" (2 words) out of union of 5 unique words
+      const result = titleSimilarity('Test-Title: A Study', 'Test Title A Study');
+      // At least "A" and "Study" should match
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('should calculate partial overlap correctly', () => {
+      const result = titleSimilarity(
+        'Machine Learning in Healthcare',
+        'Healthcare Applications of Machine Learning'
+      );
+      expect(result).toBeGreaterThan(0.4);
+      expect(result).toBeLessThan(0.8);
+    });
+
+    it('should return 0 for no overlap', () => {
+      expect(titleSimilarity('Completely Different Title', 'No Shared Words Here')).toBe(0);
+    });
+
+    it('should handle unicode/international characters', () => {
+      // The implementation strips non-ASCII word chars with /[^\w\s]/g
+      // "Méthode" -> "Mthode" (e-acute removed)
+      // "Methode" -> "Methode"
+      const result = titleSimilarity('Méthode de Calcul', 'Methode de Calcul');
+      // "de" and "Calcul" match, "Mthode" vs "Methode" don't
+      expect(result).toBeGreaterThanOrEqual(0.5);
+    });
+
+    it('should handle LaTeX-style mathematical symbols', () => {
+      // The implementation strips $ and backslash as non-word chars
+      // "On the $\alpha$-Conjecture" -> "On the alphaConjecture" (hyphen also removed)
+      // "On the alpha Conjecture" -> "On the alpha Conjecture"
+      // Word overlap depends on how chars are stripped
+      const result = titleSimilarity('On the $\\alpha$-Conjecture', 'On the alpha Conjecture');
+      // At minimum, "On", "the" should match (stop words are removed, but we check >0)
+      expect(result).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle very long titles', () => {
+      const longTitle = 'A '.repeat(100) + 'Very Long Title';
+      expect(titleSimilarity(longTitle, longTitle)).toBe(1.0);
+    });
+
+    it('should handle empty inputs', () => {
+      // Empty strings normalize to empty, so empty vs empty = 1.0 (intersection/union of empty sets)
+      expect(titleSimilarity('', '')).toBe(1.0);
+      // Non-empty vs empty = 0 (no intersection)
+      expect(titleSimilarity('Test', '')).toBe(0);
+    });
+
+    it('should throw on null/undefined inputs', () => {
+      // The function does not handle null/undefined - it will throw
+      expect(() => titleSimilarity(null as any, 'Test')).toThrow();
+      expect(() => titleSimilarity('Test', undefined as any)).toThrow();
+    });
+  });
+
+  describe('sanitizeFileName', () => {
+    let sanitizeFileName: (name: string) => string;
+
+    beforeEach(() => {
+      sanitizeFileName = createZotadataMethod('sanitizeFileName');
+    });
+
+    it('should replace invalid characters with underscore', () => {
+      expect(sanitizeFileName('file<>name')).toBe('file__name');
+      expect(sanitizeFileName('file:name')).toBe('file_name');
+      expect(sanitizeFileName('file"name')).toBe('file_name');
+      expect(sanitizeFileName('file/name\\name')).toBe('file_name_name');
+    });
+
+    it('should replace spaces with underscores', () => {
+      expect(sanitizeFileName('file name test')).toBe('file_name_test');
+    });
+
+    it('should limit length to 100 characters', () => {
+      const longName = 'a'.repeat(150);
+      expect(sanitizeFileName(longName)).toHaveLength(100);
+    });
+
+    it('should return "attachment" for empty input', () => {
+      expect(sanitizeFileName('')).toBe('attachment');
+      expect(sanitizeFileName(null as any)).toBe('attachment');
+    });
+
+    it('should handle unicode characters', () => {
+      const result = sanitizeFileName('Méthode de Calcul');
+      // Unicode chars are preserved, spaces replaced
+      expect(result).toContain('M');
+    });
+
+    it('should replace consecutive spaces with single underscore', () => {
+      // The regex /\s+/g replaces one or more consecutive spaces with a single underscore
+      // "  test  " -> "_test_" (2 spaces before and after become 1 underscore each)
+      expect(sanitizeFileName('  test  ')).toBe('_test_');
+    });
+
+    it('should handle pipe and question mark characters', () => {
+      expect(sanitizeFileName('file|name')).toBe('file_name');
+      expect(sanitizeFileName('file?name')).toBe('file_name');
+      expect(sanitizeFileName('file*name')).toBe('file_name');
+    });
+  });
+
+  describe('cleanDownloadUrl', () => {
+    let cleanDownloadUrl: (url: string) => string;
+
+    beforeEach(() => {
+      cleanDownloadUrl = createZotadataMethod('cleanDownloadUrl');
+    });
+
+    it('should remove fragment identifiers', () => {
+      expect(cleanDownloadUrl('https://example.com/file.pdf#page=1'))
+        .toBe('https://example.com/file.pdf');
+    });
+
+    it('should fix double slashes in path', () => {
+      expect(cleanDownloadUrl('https://example.com//path//file.pdf'))
+        .toBe('https://example.com/path/file.pdf');
+    });
+
+    it('should remove problematic query parameters', () => {
+      const url = 'https://example.com/file.pdf?navpanes=0&view=FitH';
+      const result = cleanDownloadUrl(url);
+      expect(result).not.toContain('navpanes');
+      expect(result).not.toContain('view');
+    });
+
+    it('should return original URL on error for invalid URL', () => {
+      // Invalid URLs that can't be parsed by URL constructor throw and return original
+      expect(cleanDownloadUrl('invalid-url')).toBe('invalid-url');
+    });
+
+    it('should handle null/undefined', () => {
+      expect(cleanDownloadUrl(null as any)).toBe(null);
+      expect(cleanDownloadUrl(undefined as any)).toBe(undefined);
+    });
+
+    it('should preserve other query parameters', () => {
+      const url = 'https://example.com/file.pdf?download=true&navpanes=0';
+      const result = cleanDownloadUrl(url);
+      expect(result).toContain('download=true');
+      expect(result).not.toContain('navpanes');
+    });
+
+    it('should handle URLs with no path', () => {
+      expect(cleanDownloadUrl('https://example.com')).toBe('https://example.com/');
+    });
+  });
+
+  describe('validatePDFData', () => {
+    let validatePDFData: (data: Uint8Array) => boolean;
+
+    beforeEach(() => {
+      validatePDFData = createZotadataMethod('validatePDFData');
+    });
+
+    it('should validate PDF with correct header and trailer', () => {
+      // Create a PDF that's at least 1024 bytes
+      // Header: '%PDF-1.4\n' = 9 bytes, Trailer: '\n%%EOF' = 6 bytes
+      // Need 1024 - 9 - 6 = 1009 bytes of padding
+      const content = '%PDF-1.4\n' + 'x'.repeat(1009) + '\n%%EOF';
+      const pdfData = new TextEncoder().encode(content);
+      expect(pdfData.length).toBeGreaterThanOrEqual(1024);
+      expect(validatePDFData(pdfData)).toBe(true);
+    });
+
+    it('should reject data too small to be valid PDF', () => {
+      const smallData = new Uint8Array(100);
+      expect(validatePDFData(smallData)).toBe(false);
+    });
+
+    it('should reject data without PDF header', () => {
+      const invalidData = new TextEncoder().encode('Not a PDF'.repeat(200));
+      expect(validatePDFData(invalidData)).toBe(false);
+    });
+
+    it('should accept PDF without %%EOF trailer', () => {
+      // Create a large enough PDF without trailer
+      const content = '%PDF-1.4\n' + 'content '.repeat(200);
+      const pdfNoTrailer = new TextEncoder().encode(content);
+      expect(validatePDFData(pdfNoTrailer)).toBe(true);
+    });
+
+    it('should accept PDF with version 2.0 header', () => {
+      // Create a PDF 2.0 that's at least 1024 bytes
+      // Header: '%PDF-2.0\n' = 9 bytes, Trailer: '\n%%EOF' = 6 bytes
+      const content = '%PDF-2.0\n' + 'x'.repeat(1009) + '\n%%EOF';
+      const pdfData = new TextEncoder().encode(content);
+      expect(pdfData.length).toBeGreaterThanOrEqual(1024);
+      expect(validatePDFData(pdfData)).toBe(true);
+    });
+
+    it('should handle empty data', () => {
+      const emptyData = new Uint8Array(0);
+      expect(validatePDFData(emptyData)).toBe(false);
+    });
+
+    it('should validate minimum size threshold of 1024 bytes', () => {
+      // Exactly 1023 bytes - should fail
+      const justUnderThreshold = new Uint8Array(1023);
+      justUnderThreshold.set(new TextEncoder().encode('%PDF-1.4'), 0);
+      expect(validatePDFData(justUnderThreshold)).toBe(false);
+
+      // Exactly 1024 bytes - should pass with valid header
+      const atThreshold = new Uint8Array(1024);
+      atThreshold.set(new TextEncoder().encode('%PDF-1.4'), 0);
+      // Add %%EOF at end for trailer
+      const eof = new TextEncoder().encode('%%EOF');
+      atThreshold.set(eof, 1024 - eof.length);
+      expect(validatePDFData(atThreshold)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for `addon/chrome/content/scripts/zotadata.js` (4,348 lines, ~80 functions) as a safety net for the planned TypeScript migration.

- **257 tests** across 9 test files
- Stratified coverage by refactoring risk (Critical → High → Medium → Lower priority)
- Mock infrastructure for Zotero globals (HTTP, Items, Translate, Prefs)
- API response fixtures for CrossRef, OpenAlex, Semantic Scholar, arXiv, Unpaywall, CORE

### Test Files

| File | Tests | Tier |
|------|-------|------|
| utils.test.ts | 32 | Critical |
| extractors.test.ts | 43 | Critical |
| isbn-convert.test.ts | 9 | Critical |
| api-clients.test.ts | 13 | High Priority |
| discovery.test.ts | 13 | High Priority |
| metadata.test.ts | 47 | High Priority |
| arxiv-processing.test.ts | 37 | High Priority |
| file-operations.test.ts | 39 | High/Medium |
| batch-processing.test.ts | 24 | Medium |

### Infrastructure

- `tests/helpers/extract-function.ts` - Extracts functions from zotadata.js for isolated testing
- `tests/__mocks__/zotero-*.ts` - Mock factories for Zotero globals
- `tests/__mocks__/fixtures/` - API response fixtures
- `tests/helpers/test-utils.ts` - Shared test utilities

## Test plan

- [x] All 257 zotadata tests pass
- [x] Mock infrastructure properly isolates tests
- [x] Fixtures provide reproducible API responses
- [x] Test coverage follows design specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)