### PR TITLE
fix: book metadata author replacement instead of duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.1] - 2025-05-02
+
+### Fixed
+
+#### Book Metadata Author Handling
+
+- **Author replacement for books** - Fixed bug where fetching metadata for books would append authors instead of replacing them, causing duplicate author entries
+- **Empty creators guard** - Added guard to preserve existing authors when translator returns empty creators array
+- **Consistent behavior** - Book metadata author handling now matches DOI-based (journal article) behavior
+
+#### Code Quality
+
+- **Removed dead code** - Cleaned up unused `allowMoreCompleteReplacement` option from translator metadata methods
+
+---
+
 ## [1.5.0] - 2025-04-30
 
 ### Added

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zotadata",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Enhance Zotero with intelligent metadata discovery and file management",
   "author": "Zotadata Team",
   "applications": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-zotadata",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Enhanced metadata management for Zotero",
   "config": {
     "addonName": "Zotadata",

--- a/src/modules/MetadataFetcher.ts
+++ b/src/modules/MetadataFetcher.ts
@@ -193,7 +193,6 @@ export class MetadataFetcher {
       },
       DOI_TRANSLATOR_FIELDS,
       {
-        allowMoreCompleteReplacement: true,
         finalizeChange: () => {
           if (String(item.getField("DOI") ?? "").trim()) {
             return false;
@@ -537,10 +536,7 @@ export class MetadataFetcher {
     item: Zotero.Item,
     identifier: Record<string, unknown>,
     fields: readonly string[],
-    options: {
-      allowMoreCompleteReplacement?: boolean;
-      finalizeChange?: () => boolean;
-    } = {},
+    options: { finalizeChange?: () => boolean } = {},
   ): Promise<boolean> {
     const translate = this.createTranslatorSearch();
     if (!translate) {
@@ -563,7 +559,6 @@ export class MetadataFetcher {
       let changed = this.applyTranslatedCreators(
         item,
         translated.getCreators(),
-        options.allowMoreCompleteReplacement ?? false,
       );
       changed = this.applyTranslatedFields(item, translated, fields) || changed;
       if (options.finalizeChange?.()) {
@@ -600,23 +595,41 @@ export class MetadataFetcher {
       firstName?: string;
       lastName?: string;
     }>,
-    allowMoreCompleteReplacement = false,
   ): boolean {
     const currentCreators = item.getCreators();
-    if (
-      currentCreators.length === 0 ||
-      (allowMoreCompleteReplacement && creators.length > currentCreators.length)
-    ) {
-      item.setCreators(
-        creators.map((creator) => ({
-          creatorType: creator.creatorType ?? "author",
-          firstName: creator.firstName ?? "",
-          lastName: creator.lastName ?? "",
-        })),
-      );
-      return creators.length > 0;
+
+    const authorsFromTranslation = creators.filter(
+      (c) => c.creatorType === "author" || !c.creatorType,
+    );
+
+    if (authorsFromTranslation.length === 0) {
+      return false;
     }
-    return false;
+
+    const nonAuthorsFromTranslation = creators.filter(
+      (c) => c.creatorType && c.creatorType !== "author",
+    );
+    const existingNonAuthors = currentCreators.filter(
+      (c) => c.creatorType !== "author",
+    );
+
+    const newAuthors = authorsFromTranslation.map((creator) => ({
+      creatorType: "author" as const,
+      firstName: creator.firstName ?? "",
+      lastName: creator.lastName ?? "",
+    }));
+
+    const newNonAuthors = nonAuthorsFromTranslation.map((creator) => ({
+      creatorType: creator.creatorType ?? "author",
+      firstName: creator.firstName ?? "",
+      lastName: creator.lastName ?? "",
+    }));
+
+    const finalNonAuthors =
+      nonAuthorsFromTranslation.length > 0 ? newNonAuthors : existingNonAuthors;
+
+    item.setCreators([...newAuthors, ...finalNonAuthors]);
+    return true;
   }
 
   private applyTranslatedFields(

--- a/src/modules/metadata/BookMetadataService.ts
+++ b/src/modules/metadata/BookMetadataService.ts
@@ -441,10 +441,7 @@ export class BookMetadataService {
     }
 
     const authors = "authors" in metadata ? metadata.authors : undefined;
-    const existingAuthors = item
-      .getCreators()
-      .filter((c) => c.creatorType === "author");
-    if (authors?.length && existingAuthors.length === 0) {
+    if (authors?.length) {
       this.applyBookAuthors(item, authors);
       changes.push(`Updated authors: ${authors.length}`);
     }
@@ -511,10 +508,7 @@ export class BookMetadataService {
     item: Zotero.Item,
     identifier: Record<string, unknown>,
     fields: readonly string[],
-    options: {
-      allowMoreCompleteReplacement?: boolean;
-      finalizeChange?: () => boolean;
-    } = {},
+    options: { finalizeChange?: () => boolean } = {},
   ): Promise<boolean> {
     const translate = this.createTranslatorSearch();
     if (!translate) {
@@ -537,7 +531,6 @@ export class BookMetadataService {
       let changed = this.applyTranslatedCreators(
         item,
         translated.getCreators(),
-        options.allowMoreCompleteReplacement ?? false,
       );
       changed = this.applyTranslatedFields(item, translated, fields) || changed;
       if (options.finalizeChange?.()) {
@@ -585,23 +578,41 @@ export class BookMetadataService {
       firstName?: string;
       lastName?: string;
     }>,
-    allowMoreCompleteReplacement = false,
   ): boolean {
     const currentCreators = item.getCreators();
-    if (
-      currentCreators.length === 0 ||
-      (allowMoreCompleteReplacement && creators.length > currentCreators.length)
-    ) {
-      item.setCreators(
-        creators.map((creator) => ({
-          creatorType: creator.creatorType ?? "author",
-          firstName: creator.firstName ?? "",
-          lastName: creator.lastName ?? "",
-        })),
-      );
-      return creators.length > 0;
+
+    const authorsFromTranslation = creators.filter(
+      (c) => c.creatorType === "author" || !c.creatorType,
+    );
+
+    if (authorsFromTranslation.length === 0) {
+      return false;
     }
-    return false;
+
+    const nonAuthorsFromTranslation = creators.filter(
+      (c) => c.creatorType && c.creatorType !== "author",
+    );
+    const existingNonAuthors = currentCreators.filter(
+      (c) => c.creatorType !== "author",
+    );
+
+    const newAuthors = authorsFromTranslation.map((creator) => ({
+      creatorType: "author" as const,
+      firstName: creator.firstName ?? "",
+      lastName: creator.lastName ?? "",
+    }));
+
+    const newNonAuthors = nonAuthorsFromTranslation.map((creator) => ({
+      creatorType: creator.creatorType ?? "author",
+      firstName: creator.firstName ?? "",
+      lastName: creator.lastName ?? "",
+    }));
+
+    const finalNonAuthors =
+      nonAuthorsFromTranslation.length > 0 ? newNonAuthors : existingNonAuthors;
+
+    item.setCreators([...newAuthors, ...finalNonAuthors]);
+    return true;
   }
 
   private applyTranslatedFields(


### PR DESCRIPTION
- Fixed bug where fetching metadata for books would append authors instead of replacing them
- Added guard to preserve existing authors when translator returns empty creators
- Removed unused allowMoreCompleteReplacement option
- Bumped version to 1.5.1